### PR TITLE
feature: Implement CounterBox labels for chat inputs

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -82,7 +82,14 @@ Cell[
     CellGroupingRules -> "InputGrouping",
     CellFrameColor    -> RGBColor[ "#a3c9f2" ],
     CellMargins       -> { { 66, 25 }, { 5, 8 } },
-    CellDingbat       -> Cell[ BoxData @ TemplateBox[ { }, "ChatUserIcon" ], Background -> None ],
+    CellDingbat       -> Cell[
+        BoxData @ RowBox[{
+            TemplateBox[{}, "ChatCounterLabel"],
+            TemplateBox[{}, "ChatUserIcon"]
+        }],
+        Background -> None
+    ],
+    CounterIncrements -> {"ChatInputCount"},
     StyleKeyMapping   -> { " " -> "Text", "*" -> "Item", "'" -> "ChatQuery", "Backspace" -> "Input" },
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
     menuInitializer[ "ChatInput", RGBColor[ "#d1d9ea" ] ]
@@ -147,6 +154,7 @@ Cell[
     DefaultNewCellStyle -> "Input",
     FontColor           -> GrayLevel[ 0.2 ],
     FontWeight          -> "DemiBold",
+    CounterAssignments  -> {{"ChatInputCount", 0}},
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
 
     StyleKeyMapping -> {
@@ -174,6 +182,7 @@ Cell[
     DefaultNewCellStyle    -> "Input",
     FontSize               -> 6,
     ShowCellLabel          -> False,
+    CounterAssignments     -> {{"ChatInputCount", 0}},
 
     CellEventActions -> {
         "KeyDown" :> Switch[
@@ -659,6 +668,22 @@ Cell[
     FontWeight      -> Plain,
     LineBreakWithin -> False,
     LineIndent      -> 0
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*ChatCounterLabel*)
+Cell[
+    StyleData["ChatCounterLabel"],
+    TemplateBoxOptions -> {
+        DisplayFunction -> Function @ StyleBox[
+            CounterBox["ChatInputCount"],
+            FontFamily -> "Source Sans Pro",
+            FontSize -> 10,
+            FontColor -> GrayLevel[ 0.2 ],
+            FontWeight -> Plain
+        ]
+    }
 ]
 
 (* ::**************************************************************************************************************:: *)

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -596,7 +596,14 @@ Notebook[
    ],
    CellDingbat ->
     Cell[
-     BoxData[TemplateBox[{}, "ChatUserIcon"]],
+     BoxData[
+      RowBox[
+       {
+        TemplateBox[{}, "ChatCounterLabel"],
+        TemplateBox[{}, "ChatUserIcon"]
+       }
+      ]
+     ],
      Background -> None
     ],
    CellMargins -> {{66, 25}, {5, 8}},
@@ -633,6 +640,7 @@ Notebook[
      ]
     ],
    CellFrameColor -> RGBColor[0.63922, 0.78824, 0.94902],
+   CounterIncrements -> {"ChatInputCount"},
    MenuSortingValue -> 1000
   ],
   Cell[
@@ -812,6 +820,7 @@ Notebook[
    ShowCellLabel -> False,
    CellFrameColor -> GrayLevel[0.74902],
    DefaultNewCellStyle -> "Input",
+   CounterAssignments -> {{"ChatInputCount", 0}},
    FontWeight -> "DemiBold",
    FontColor -> GrayLevel[0.2]
   ],
@@ -867,6 +876,7 @@ Notebook[
     {None, None}
    },
    DefaultNewCellStyle -> "Input",
+   CounterAssignments -> {{"ChatInputCount", 0}},
    FontSize -> 6,
    Background -> GrayLevel[0.95]
   ],
@@ -3339,8 +3349,23 @@ Notebook[
    FontSize -> 13,
    FontWeight -> Plain,
    FontColor -> GrayLevel[0.2]
+  ],
+  Cell[
+   StyleData["ChatCounterLabel"],
+   TemplateBoxOptions -> {
+    DisplayFunction ->
+     (Function[
+      StyleBox[
+       CounterBox["ChatInputCount"],
+       FontFamily -> "Source Sans Pro",
+       FontSize -> 10,
+       FontColor -> GrayLevel[0.2],
+       FontWeight -> Plain
+      ]
+     ])
+   }
   ]
  },
- FrontEndVersion -> "13.2 for Microsoft Windows (64-bit) (January 30, 2023)",
+ FrontEndVersion -> "13.2 for Mac OS X ARM (64-bit) (November 18, 2022)",
  StyleDefinitions -> "PrivateStylesheetFormatting.nb"
 ]


### PR DESCRIPTION
**Chat inputs have counters:**

![chat-input-counters](https://user-images.githubusercontent.com/5759631/234131824-d803ec3b-4e90-4f83-808c-62ff168bd597.gif)

**Dividers reset the counter:**

![chat-counters-dividers-reset-counter](https://user-images.githubusercontent.com/5759631/234131842-b310ae55-89a0-42c7-9cfe-03a476e36e0e.gif)

**Physically reordering cells get updated numbering:**

![chat-counters-reordering-updates-counters](https://user-images.githubusercontent.com/5759631/234131847-8e34ba78-d54c-489b-931d-837464088b71.gif)


I think this feature has a number of nice benefits:

* The presence of an incrementing counter helps users learn that chat inputs are related to each other.

* Counters strengthens the analogy between chat inputs and Kernel inputs.

* CounterBox's are based on physical ordering in a notebook, not temporal ordering. So:

  - Manually reordered chat input cells will have their counter labels updated automatically

  - Inserting a chat divider will automatically update the numbering of subsequent chat inputs. This helps teach people what dividers do.

