### PR TITLE
Add "PrimaryContext" to PacletInfo.wl

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -14,6 +14,7 @@ PacletObject[<|
 		this paclet. This is a workaround used to prevent the contexts from this
 		paclet from being present in $ContextPath post Kernel-startup. *)
 	"Loading" -> "Startup",
+    "PrimaryContext" -> "Wolfram`Chatbook`",
 	"Extensions" -> {
 		{"Kernel", "Root" -> "Source/Startup/Begin", "Context" -> "Wolfram`Chatbook`BeginStartup`"},
 		{"Kernel",


### PR DESCRIPTION
@ConnorGray we'll also need this to be specified in the definition notebook.

On that note, I have a script to automatically format notebooks as a git pre-commit hook, which would make dealing with definition notebook changes easier to manage.

Example: https://github.com/rhennigan/CodeEquivalenceUtilities/blob/main/ResourceDefinition.nb

Here's the script I use: https://github.com/rhennigan/CodeEquivalenceUtilities/blob/main/Scripts/FormatFiles.wls

I can add a similar script to this repo if you want to start including the definition notebook.

We'll also need the definition notebook in source control for CI/CD as well.