### PR TITLE
Bugfix: Persona Output Icons and Minimized Chats Cleanup

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -2430,8 +2430,9 @@ resizeDingbat[ icon_ ] /; $resizeDingbats := Pane[
     icon,
     ContentPadding  -> False,
     FrameMargins    -> 0,
-    ImageSize       -> { 20, 20 },
-    ImageSizeAction -> "ShrinkToFit"
+    ImageSize       -> { 35, 35 },
+    ImageSizeAction -> "ShrinkToFit",
+    Alignment       -> { Center, Center }
 ];
 
 resizeDingbat[ icon_ ] := icon;


### PR DESCRIPTION
(Pull request authored by [Birdnardo](https://resources.wolframcloud.com/PromptRepository/resources/Birdnardo/))

This PR addresses two issues:

1. Clear minimized chats when evaluating ChatInput cells and properly clean up tasks (dbe1287). This resolves an issue where minimized chat from previous Input evaluations would block ChatInput evaluations (#131).

2. Fix the Persona output icons resizing issue, as they were being resized too small (2cee483). The icons' size has been adjusted to look cooler now.

Rock on! 🎸