### PR TITLE
polish: Prevent the 'Advanced Settings' submenu from touching the right notebook window edge

### DIFF
--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -2122,14 +2122,36 @@ makeChatActionMenuContent[
 					}},
 					Spacings -> 0
 				],
-				Hold[AttachCell[
-					EvaluationCell[],
-					advancedSettingsMenu,
-					{Right, Bottom},
-					{50, 50},
-					{Left, Bottom},
-					RemovalConditions -> "MouseExit"
-				]]
+				Hold @ With[{
+					mouseX = MousePosition["WindowScaled"][[1]]
+				}, {
+					(* Note: Depending on the X coordinate of the users mouse
+						when they click the 'Advanced Settings' button, either
+						show the attached submenu to the left or right of the
+						outer menu. This ensures that this submenu doesn't touch
+						the right edge of the notebook window when it is opened
+						from the 'Chat Settings' notebook toolbar. *)
+					positions = If[
+						TrueQ[mouseX < 0.5],
+						{
+							{Right, Bottom},
+							{Left, Bottom}
+						},
+						{
+							{Left, Bottom},
+							{Right, Bottom}
+						}
+					]
+				},
+					AttachCell[
+						EvaluationCell[],
+						advancedSettingsMenu,
+						positions[[1]],
+						{50, 50},
+						positions[[2]],
+						RemovalConditions -> "MouseExit"
+					]
+				]
 			}
 		}
 	];


### PR DESCRIPTION
Opening 'Advanced Settings' from the cell dingbat typically attaches to the _right_ side:

![Screen Shot 2023-06-08 at 12 17 15 PM](https://github.com/WolframResearch/Chatbook/assets/5759631/681d059e-5c40-4476-8072-d3c1fb9c973e)

Opening 'Advanced Settings' from the notebook toolbar dingbat typically attaches to the _left_ side:

![Screen Shot 2023-06-08 at 12 17 43 PM](https://github.com/WolframResearch/Chatbook/assets/5759631/61e57988-a6bc-44c0-93ec-b85ffb81451f)
