### PR TITLE
Bugfix: Fix cell dingbats for chat block dividers in cloud showing as an empty string

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -340,8 +340,8 @@ Cell[
                     StandardForm
                 ],
                 "Text",
-                Background  -> None,
-                CellFrame   -> 0,
+                Background           -> None,
+                CellFrame            -> 0,
                 CellMargins          -> 0,
                 ShowStringCharacters -> False
             ],
@@ -368,6 +368,7 @@ Cell[
     CounterAssignments     -> { { "ChatInputCount", 0 } },
     FontSize               -> 6,
     ShowCellLabel          -> False,
+    StyleKeyMapping        -> { "~" -> "ChatBlockDivider", "'" -> "ChatInput" },
 
     CellEventActions -> {
         "KeyDown" :> Switch[
@@ -396,8 +397,8 @@ Cell[
                     ],
                     StandardForm
                 ],
-                Background    -> None,
-                CellFrame     -> 0,
+                Background           -> None,
+                CellFrame            -> 0,
                 CellMargins          -> 0,
                 ShowStringCharacters -> False
             ],

--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -342,7 +342,8 @@ Cell[
                 "Text",
                 Background  -> None,
                 CellFrame   -> 0,
-                CellMargins -> 0
+                CellMargins          -> 0,
+                ShowStringCharacters -> False
             ],
             None
         },
@@ -397,7 +398,8 @@ Cell[
                 ],
                 Background    -> None,
                 CellFrame     -> 0,
-                CellMargins   -> 0
+                CellMargins          -> 0,
+                ShowStringCharacters -> False
             ],
             None
         },

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -2264,7 +2264,8 @@ Notebook[
       "Text",
       Background -> None,
       CellFrame -> 0,
-      CellMargins -> 0
+      CellMargins -> 0,
+      ShowStringCharacters -> False
      ],
      None
     },
@@ -2278,6 +2279,7 @@ Notebook[
    StyleData["ChatDelimiter"],
    CellMargins -> {{5, 0}, {10, 10}},
    CellElementSpacings -> {"CellMinHeight" -> 6},
+   StyleKeyMapping -> {"~" -> "ChatBlockDivider", "'" -> "ChatInput"},
    CellGroupingRules -> {"SectionGrouping", 62},
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    Initialization :>
@@ -2337,7 +2339,8 @@ Notebook[
       ],
       Background -> None,
       CellFrame -> 0,
-      CellMargins -> 0
+      CellMargins -> 0,
+      ShowStringCharacters -> False
      ],
      None
     },


### PR DESCRIPTION
## Before

<img width="270" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/23fdb448-7fef-4b24-95ee-6073b5fc259b">

## After

<img width="363" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/e279cdc2-f58e-4a63-8b43-ed563173d0eb">
