### PR TITLE
feature/hotfix: Improve global chat preferences content

### DIFF
--- a/LLMConfiguration/Personas/Birdnardo/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/Birdnardo/LLMConfiguration.wl
@@ -1,0 +1,3 @@
+<|
+	"Description" -> "The one and only Birdnardo"
+|>

--- a/LLMConfiguration/Personas/CodeAssistant/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/CodeAssistant/LLMConfiguration.wl
@@ -2,5 +2,6 @@
     "BasePrompt"  -> { "WolframLanguageStyle" },
     "DisplayName" -> "Code Assistant",
     "Icon"        -> RawBoxes @ TemplateBox[ { }, "ChatIconCodeAssistant" ],
-    "Tools"       -> { "DocumentationLookup", "DocumentationSearch", "WolframAlpha", "WolframLanguageEvaluator" }
+    "Tools"       -> { "DocumentationLookup", "DocumentationSearch", "WolframAlpha", "WolframLanguageEvaluator" },
+    "Description" -> "Help writing and generating Wolfram Language code"
 |>

--- a/LLMConfiguration/Personas/CodeWriter/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/CodeWriter/LLMConfiguration.wl
@@ -2,5 +2,6 @@
     "BasePrompt"  -> { "WolframLanguageStyle" },
     "DisplayName" -> "Code Writer",
     "Icon"        -> RawBoxes @ TemplateBox[ { }, "ChatIconCodeWriter" ],
-    "Tools"       -> { "DocumentationLookup", "DocumentationSearch", "WolframAlpha", "WolframLanguageEvaluator" }
+    "Tools"       -> { "DocumentationLookup", "DocumentationSearch", "WolframAlpha", "WolframLanguageEvaluator" },
+    "Description" -> "AI code generation without the chatter"
 |>

--- a/LLMConfiguration/Personas/PlainChat/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/PlainChat/LLMConfiguration.wl
@@ -3,5 +3,6 @@
     "DisplayName" -> "Plain Chat",
     "Icon"        -> RawBoxes @ TemplateBox[ { }, "ChatIconPlainChat" ],
     "Pre"         -> "",
-    "Tools"       -> { "WebSearch", "WebImageSearch", "WebFetch" }
+    "Tools"       -> { "WebSearch", "WebImageSearch", "WebFetch" },
+    "Description" -> "Chat about anything"
 |>

--- a/LLMConfiguration/Personas/RawModel/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/RawModel/LLMConfiguration.wl
@@ -1,5 +1,6 @@
 <|
     "BasePrompt"  -> None,
 	"DisplayName" -> "Raw Model",
-    "Icon"        -> RawBoxes @ TemplateBox[ { }, "PersonaRawModel" ]
+    "Icon"        -> RawBoxes @ TemplateBox[ { }, "PersonaRawModel" ],
+    "Description" -> "No custom prompting, just the raw LLM"
 |>

--- a/LLMConfiguration/Personas/Wolfie/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/Wolfie/LLMConfiguration.wl
@@ -1,0 +1,3 @@
+<|
+	"Description" -> "Wolfram's friendliest AI guide"
+|>

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -18,6 +18,7 @@ BeginPackage[ "Wolfram`Chatbook`Actions`" ];
 `WidgetSend;
 
 `$settings;
+`autoAssistQ;
 
 Begin[ "`Private`" ];
 
@@ -396,6 +397,15 @@ autoAssistQ[ info_, cell_CellObject, nbo_NotebookObject ] :=
 autoAssistQ[ True|Automatic|Inherited, True|Automatic|Inherited ] := True;
 autoAssistQ[ _, True|Automatic ] := True;
 autoAssistQ[ _, _ ] := False;
+
+(* Determine if auto assistance is enabled generally within a FE or Notebook. *)
+autoAssistQ[
+	target: _FrontEndObject | $FrontEndSession | _NotebookObject
+] :=
+	autoAssistQ[
+		Inherited,
+		currentChatSettings[ target, "Assistance" ]
+	]
 
 autoAssistQ // endDefinition;
 

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -537,44 +537,6 @@ makeFrontEndAndNotebookSettingsContent[
 		personas
 	];
 
-	defaultPersonaPopupItems = Append[
-		defaultPersonaPopupItems,
-		Inherited -> Row[{
-			"Inherited",
-			Spacer[3],
-			Dynamic @ With[{
-				currentValue = CurrentValue[
-					targetObj,
-					{TaggingRules, "ChatNotebookSettings", "LLMEvaluator"}
-				],
-				absoluteCurrentValue = AbsoluteCurrentValue[
-					targetObj,
-					{TaggingRules, "ChatNotebookSettings", "LLMEvaluator"}
-				]
-			},
-				(* NOTE:
-					If `targetObj` is a NotebookObject and the local value of
-					LLMEvaluator is not set (i.e. currentValue === Inherited),
-					then display the inherited persona in italics.
-				*)
-				If[currentValue === Inherited && absoluteCurrentValue =!= Inherited,
-					Style[
-						Row[{
-							"(",
-							If[StringQ[absoluteCurrentValue],
-								personaDisplayName[absoluteCurrentValue],
-								personaDisplayName
-							],
-							")"
-						}],
-						Italic
-					],
-					Row[{}]
-				]
-			]
-		}]
-	];
-
 	(*---------------------------------*)
 	(* Return the toolbar menu content *)
 	(*---------------------------------*)
@@ -584,9 +546,17 @@ makeFrontEndAndNotebookSettingsContent[
 			{Row[{
 				tr["Default LLM Evaluator:"],
 				PopupMenu[
-					Dynamic @ CurrentValue[
-						targetObj,
-						{TaggingRules, "ChatNotebookSettings", "LLMEvaluator"}
+					Dynamic[
+						currentChatSettings[
+							targetObj,
+							"LLMEvaluator"
+						],
+						Function[{newValue},
+							CurrentValue[
+								targetObj,
+								{TaggingRules, "ChatNotebookSettings", "LLMEvaluator"}
+							] = newValue
+						]
 					],
 					defaultPersonaPopupItems
 				]

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -308,43 +308,7 @@ CreateToolbarContent[] := With[{
 					Column[{
 						makeEnableAIChatFeaturesLabel[True],
 
-						labeledCheckbox[
-							Dynamic[
-								TrueQ[
-									CurrentValue[
-										EvaluationNotebook[],
-										{TaggingRules, "ChatNotebookSettings", "Assistance"}
-									]
-								],
-								Function[
-									If[
-										SameQ[
-											#,
-											AbsoluteCurrentValue[
-												$FrontEndSession,
-												{TaggingRules, "ChatNotebookSettings", "Assistance"}
-											]
-										],
-										CurrentValue[
-											EvaluationNotebook[],
-											{TaggingRules, "ChatNotebookSettings", "Assistance"}
-										] = Inherited,
-										CurrentValue[
-											EvaluationNotebook[],
-											{TaggingRules, "ChatNotebookSettings", "Assistance"}
-										] = #
-									]
-								]
-							],
-							Row[{
-								"Automatic Result Analysis",
-								Spacer[3],
-								Tooltip[
-									getIcon["InformationTooltip"],
-									"If enabled, automatic AI provided suggestions will be added following evaluation results."
-								]
-							}]
-						],
+						makeAutomaticResultAnalysisCheckbox[],
 
 						makeChatActionMenu[
 							"Toolbar",
@@ -447,6 +411,49 @@ SetFallthroughError[makeEnableAIChatFeaturesLabel]
 
 makeEnableAIChatFeaturesLabel[enabled_?BooleanQ] :=
 	labeledCheckbox[enabled, "Enable AI Chat Features", !enabled]
+
+(*====================================*)
+
+SetFallthroughError[makeAutomaticResultAnalysisCheckbox]
+
+makeAutomaticResultAnalysisCheckbox[] :=
+	labeledCheckbox[
+		Dynamic[
+			TrueQ[
+				CurrentValue[
+					EvaluationNotebook[],
+					{TaggingRules, "ChatNotebookSettings", "Assistance"}
+				]
+			],
+			Function[
+				If[
+					SameQ[
+						#,
+						AbsoluteCurrentValue[
+							$FrontEndSession,
+							{TaggingRules, "ChatNotebookSettings", "Assistance"}
+						]
+					],
+					CurrentValue[
+						EvaluationNotebook[],
+						{TaggingRules, "ChatNotebookSettings", "Assistance"}
+					] = Inherited,
+					CurrentValue[
+						EvaluationNotebook[],
+						{TaggingRules, "ChatNotebookSettings", "Assistance"}
+					] = #
+				]
+			]
+		],
+		Row[{
+			"Automatic Result Analysis",
+			Spacer[3],
+			Tooltip[
+				getIcon["InformationTooltip"],
+				"If enabled, automatic AI provided suggestions will be added following evaluation results."
+			]
+		}]
+	]
 
 (*====================================*)
 

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -218,13 +218,7 @@ CreatePreferencesContent[] := Module[{
 		Prepend[
 			KeyValueMap[
 				{persona, personaSettings} |-> {
-					Replace[Lookup[personaSettings, "Icon", None], {
-						None -> "",
-						RawBoxes[TemplateBox[{}, iconStyle_?StringQ]] :> (
-							chatbookIcon[iconStyle, False]
-						),
-						icon_ :> icon
-					}],
+					getPersonaMenuIcon[personaSettings, "Full"],
 					personaDisplayName[persona, personaSettings],
 					Replace[Lookup[personaSettings, "Description", None], {
 						None | _?MissingQ -> "",
@@ -250,7 +244,7 @@ CreatePreferencesContent[] := Module[{
 
 	chatbookSettings = makeFrontEndAndNotebookSettingsContent[$FrontEnd];
 
-	services = Grid[{
+	(* services = Grid[{
 			{""									, "Name"	, "State" 						},
 			{chatbookIcon["OpenAILogo", False]	, "OpenAI"	, "<Connected>" 				},
 			{""									, "Bard"	, Style["Coming soon", Italic]	},
@@ -259,7 +253,7 @@ CreatePreferencesContent[] := Module[{
 		Background -> {None, {1 -> GrayLevel[0.95]}},
 		Dividers -> {False, {False, {1 -> True, 2 -> True}}},
 		Alignment -> {Left, Center}
-	];
+	]; *)
 
 	(*-----------------------------------------*)
 	(* Return the complete settings expression *)
@@ -274,11 +268,11 @@ CreatePreferencesContent[] := Module[{
 			PrefUtils`PreferencesSection[
 				Style[tr["Installed LLM Evaluators"], "subsectionText"],
 				llmEvaluatorNamesSettings
-			],
-			PrefUtils`PreferencesSection[
+			]
+			(* PrefUtils`PreferencesSection[
 				Style[tr["LLM Service Providers"], "subsectionText"],
 				services
-			]
+			] *)
 		},
 		PrefUtils`PreferencesResetButton[
 			FrontEndExecute @ FrontEnd`RemoveOptions[$FrontEnd, {
@@ -489,7 +483,7 @@ makeFrontEndAndNotebookSettingsContent[
 		{persona, personaSettings} |-> (
 			persona -> Row[{
 				resizeMenuIcon[
-					getPersonaMenuIcon[personaSettings]
+					getPersonaMenuIcon[personaSettings, "Full"]
 				],
 				personaDisplayName[persona, personaSettings]
 			}, Spacer[1]]
@@ -2387,6 +2381,17 @@ getPersonaMenuIcon[ KeyValuePattern[ "Icon"|"PersonaIcon" -> icon_ ] ] := getPer
 getPersonaMenuIcon[ KeyValuePattern[ "Default" -> icon_ ] ] := getPersonaMenuIcon @ icon;
 getPersonaMenuIcon[ _Missing | _Association | None ] := RawBoxes @ TemplateBox[ { }, "PersonaUnknown" ];
 getPersonaMenuIcon[ icon_ ] := icon;
+
+(* If "Full" is specified, resolve TemplateBox icons into their literal
+   icon data, so that they will render correctly in places where the Chatbook.nb
+   stylesheet is not available. *)
+getPersonaMenuIcon[ expr_, "Full" ] :=
+	Replace[getPersonaMenuIcon[expr], {
+		RawBoxes[TemplateBox[{}, iconStyle_?StringQ]] :> (
+			chatbookIcon[iconStyle, False]
+		),
+		icon_ :> icon
+	}]
 
 
 


### PR DESCRIPTION
* Descriptions are now shown for listed personas
* The 'Inherited' value for Default LLM Evaluator and Automatic Result Analysis no longer displays as a special state; instead the default value ('Chat Assistant', 'True') is shown.
* Fixed icons in Default LLM Evaluator dropdown not displaying correctly.
* The unfinished 'LLM Service Providers' section has been temporarily removed.

![CleanShot 2023-06-27 at 13 03 48](https://github.com/WolframResearch/Chatbook/assets/5759631/68a56b02-faa7-4d2c-a4f5-49c7b8bb613e)
