### PR TITLE
Fixed `AIAutoAssist` cancelling chats in progress

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -3,7 +3,7 @@
 PacletObject[<|
 	"Name" -> "Wolfram/Chatbook",
 	"PublisherID" -> "Wolfram",
-	"Version" -> "1.0.1",
+	"Version" -> "1.0.2",
 	"WolframVersion" -> "13.2+",
 	"Description" -> "Wolfram Notebooks + LLMs",
 	"License" -> "MIT",

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -59,7 +59,6 @@ ChatbookAction[ "InsertInlineReference", args___ ] := catchMine @ InsertInlineRe
 ChatbookAction[ "OpenChatBlockSettings", args___ ] := catchMine @ OpenChatBlockSettings @ args;
 ChatbookAction[ "OpenChatMenu"         , args___ ] := catchMine @ OpenChatMenu @ args;
 ChatbookAction[ "PersonaManage"        , args___ ] := catchMine @ PersonaManage @ args;
-ChatbookAction[ "PersonaURLInstall"    , args___ ] := catchMine @ PersonaURLInstall @ args;
 ChatbookAction[ "Send"                 , args___ ] := catchMine @ SendChat @ args;
 ChatbookAction[ "StopChat"             , args___ ] := catchMine @ StopChat @ args;
 ChatbookAction[ "TabLeft"              , args___ ] := catchMine @ TabLeft @ args;

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -304,8 +304,10 @@ EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject ] :=
 EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject, settings_Association? AssociationQ ] :=
     withChatState @ Block[ { $autoAssistMode = False },
         clearMinimizedChats @ nbo;
-        waitForLastTask[ ];
-        sendChat[ evalCell, nbo, settings ]
+        WithCleanup[
+            sendChat[ evalCell, nbo, settings ],
+            waitForLastTask[ ]
+        ]
     ];
 
 EvaluateChatInput // endDefinition;


### PR DESCRIPTION
The auto assistance will no longer cancel a normal chat that's currently in progress:

![EvaluateChatInputTaskWait](https://github.com/WolframResearch/Chatbook/assets/6674723/0e892ad3-3cc0-44e3-9733-1478800331d4)

Old behavior:
![AIAutoAssistCancelChat](https://github.com/WolframResearch/Chatbook/assets/6674723/f2b0af54-7fcc-408a-a350-038fc7bd7522)
