### PR TITLE
Normalize UTF-8 characters before parsing the tool request

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1337,7 +1337,7 @@ checkResponse[ settings_, container_Symbol, cell_, as_Association ] := Enclose[
         string = ConfirmBy[ container[ "FullContent" ], StringQ, "FullContent" ];
 
         { callPos, toolCall } = ConfirmMatch[
-            $toolConfiguration[ "ToolRequestParser" ][ string ],
+            $toolConfiguration[ "ToolRequestParser" ][ convertUTF8[ string, False ] ],
             { _, _LLMToolRequest|_Failure },
             "ToolRequestParser"
         ];
@@ -2794,7 +2794,9 @@ openChatCell // endDefinition;
 (* ::Subsection::Closed:: *)
 (*convertUTF8*)
 convertUTF8 // beginDefinition;
-convertUTF8[ string_String ] := FromCharacterCode[ ToCharacterCode @ string, "UTF-8" ];
+convertUTF8[ string_String ] := convertUTF8[ string, True ];
+convertUTF8[ string_String, True  ] := FromCharacterCode[ ToCharacterCode @ string, "UTF-8" ];
+convertUTF8[ string_String, False ] := FromCharacterCode @ ToCharacterCode[ string, "UTF-8" ];
 convertUTF8 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
# Before
<img width="667" alt="Screenshot 2023-07-17 171221" src="https://github.com/WolframResearch/Chatbook/assets/6674723/da778355-2313-4574-9333-cea8cb1daca0">

# After
<img width="659" alt="Screenshot 2023-07-17 171639" src="https://github.com/WolframResearch/Chatbook/assets/6674723/c3f0e8ef-52f0-4a47-b0f0-91237d1a3d5b">
