### PR TITLE
Avoid doing partial string replacements for language names

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -3,7 +3,7 @@
 PacletObject[<|
 	"Name" -> "Wolfram/Chatbook",
 	"PublisherID" -> "Wolfram",
-	"Version" -> "1.0.2",
+	"Version" -> "1.0.3",
 	"WolframVersion" -> "13.2+",
 	"Description" -> "Wolfram Notebooks + LLMs",
 	"License" -> "MIT",

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -47,15 +47,19 @@ $tinyLineBreak = StyleBox[ "\n", "TinyLineBreak", FontSize -> 3 ];
 
 $$externalLanguage = "Java"|"Julia"|"Jupyter"|"NodeJS"|"Octave"|"Python"|"R"|"Ruby"|"Shell"|"SQL"|"SQL-JDBC";
 
-$externalLanguageRules = Flatten @ {
-    "JS"         -> "NodeJS",
-    "Javascript" -> "NodeJS",
-    "NPM"        -> "NodeJS",
-    "Node"       -> "NodeJS",
-    "Bash"       -> "Shell",
-    "SH"         -> "Shell",
-    Cases[ $$externalLanguage, lang_ :> (lang -> lang) ]
-};
+$externalLanguageRules = Replace[
+    Flatten @ {
+        "JS"         -> "NodeJS",
+        "Javascript" -> "NodeJS",
+        "NPM"        -> "NodeJS",
+        "Node"       -> "NodeJS",
+        "Bash"       -> "Shell",
+        "SH"         -> "Shell",
+        Cases[ $$externalLanguage, lang_ :> (lang -> lang) ]
+    },
+    HoldPattern[ lhs_ -> rhs_ ] :> (StartOfString~~lhs~~EndOfString -> rhs),
+    { 1 }
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)


### PR DESCRIPTION
# Old Behavior
![BadFormattingToggle](https://github.com/WolframResearch/Chatbook/assets/6674723/0e0a6a87-2021-4976-9586-3572a2b9a8ac)

# New Behavior
![GoodFormattingToggle](https://github.com/WolframResearch/Chatbook/assets/6674723/734e75b0-c3ac-430a-b7fd-3369817e9a79)
