### PR TITLE
Give a `ChatObject` as suppressed output when evaluating chat inputs

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -302,11 +302,17 @@ EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject ] :=
 
 EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject, settings_Association? AssociationQ ] :=
     withChatState @ Block[ { $autoAssistMode = False },
+        $lastMessages   = None;
+        $lastChatString = None;
         clearMinimizedChats @ nbo;
         WithCleanup[
             sendChat[ evalCell, nbo, settings ],
             waitForLastTask[ ]
-        ]
+        ];
+        If[ ListQ @ $lastMessages && StringQ @ $lastChatString,
+            constructChatObject @ Append[ $lastMessages, <| "role" -> "Assistant", "content" -> $lastChatString |> ],
+            Null
+        ];
     ];
 
 EvaluateChatInput // endDefinition;
@@ -2829,6 +2835,7 @@ writeReformattedCell[ settings_, string_String, cell_CellObject ] :=
             pageData = CurrentValue[ cell, { TaggingRules, "PageData" } ],
             uuid     = CreateUUID[ ]
         },
+        $lastChatString = string;
         Block[ { $dynamicText = False },
             (* Global`oldCellContent = NotebookRead @ cell; *)
             WithCleanup[


### PR DESCRIPTION
Evaluating a chat input will now leave a `ChatObject[...]` in `%`:
<img width="583" alt="Screenshot 2023-07-18 134837" src="https://github.com/WolframResearch/Chatbook/assets/6674723/e0ab0a24-3171-4f5e-97aa-1ef294d1a549">

This was previously giving the `TaskObject[...]` that was used in `URLSubmit`.

This will also now give more useful outputs when using `NotebookEvaluate` on chat notebooks