### PR TITLE
Do not serialize "ChatDelimiter" cells

### DIFF
--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -29,7 +29,7 @@ Needs[ "Wolfram`Chatbook`FrontEnd`"   ];
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*Config*)
-$$delimiterStyle   = "PageBreak"|"ExampleDelimiter"|"ChatDelimiter";
+$$delimiterStyle   = "PageBreak"|"ExampleDelimiter";
 $$itemStyle        = "Item"|"Notes";
 $$noCellLabelStyle = "Text"|"ChatInput"|"SideChat"|"ChatSystemInput"|"ChatBlockDivider"|$$delimiterStyle;
 $$docSearchStyle   = "ChatQuery";


### PR DESCRIPTION
This prevents chats from starting with a "---" when a chat delimiter is used:
<img width="656" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/b41727fa-7d39-4eb2-b9f8-1ff148008ee4">

Old behavior:
![image](https://github.com/WolframResearch/Chatbook/assets/6674723/928692d5-06bc-4f41-af0a-3cd32561c98b)
