### PR TITLE
Delay evaluation of `ChatObject` until needed

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -456,7 +456,13 @@ CopyChatObject // endDefinition;
 constructChatObject // beginDefinition;
 
 constructChatObject[ messages_List ] :=
-    With[ { chat = chatObject[ Append[ KeyMap[ Capitalize, #1 ], "Timestamp" -> Now ] & /@ messages ] },
+    Module[ { data, chat },
+        data = <| |>;
+        data[ "Messages" ] = MapAt[ Capitalize, KeyMap[ Capitalize, #1 ] & /@ messages, { All, "Role" } ];
+        data[ "ChatID"   ] = CreateUUID[ ];
+        data[ "History"  ] = { };
+        data[ "Usage"    ] = 0;
+        chat = chatObject @ data;
         chat /; MatchQ[ chat, _chatObject ]
     ];
 

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -309,13 +309,34 @@ EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject, settings_Association
         clearMinimizedChats @ nbo;
         sendChat[ evalCell, nbo, settings ];
         waitForLastTask[ ];
-        If[ ListQ @ $lastMessages && StringQ @ $lastChatString,
-            constructChatObject @ Append[ $lastMessages, <| "role" -> "Assistant", "content" -> $lastChatString |> ],
-            Null
-        ];
+        blockChatObject[
+            If[ ListQ @ $lastMessages && StringQ @ $lastChatString,
+                constructChatObject @ Append[
+                    $lastMessages,
+                    <| "role" -> "Assistant", "content" -> $lastChatString |>
+                ],
+                Null
+            ];
+        ]
     ];
 
 EvaluateChatInput // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*blockChatObject*)
+blockChatObject // beginDefinition;
+blockChatObject // Attributes = { HoldFirst };
+blockChatObject[ eval_ ] /; Quiet @ PacletNewerQ[ PacletObject[ "Wolfram/LLMFunctions" ], "1.1.0" ] := eval;
+blockChatObject[ eval_ ]  := Block[ { System`ChatObject = delayedChatObject, delayedChatObject }, eval ];
+blockChatObject // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*delayedChatObject*)
+delayedChatObject // beginDefinition;
+delayedChatObject[ args___ ] := delayedChatObject[ args ] = System`ChatObject @ args;
+delayedChatObject // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -456,13 +477,7 @@ CopyChatObject // endDefinition;
 constructChatObject // beginDefinition;
 
 constructChatObject[ messages_List ] :=
-    Module[ { data, chat },
-        data = <| |>;
-        data[ "Messages" ] = MapAt[ Capitalize, KeyMap[ Capitalize, #1 ] & /@ messages, { All, "Role" } ];
-        data[ "ChatID"   ] = CreateUUID[ ];
-        data[ "History"  ] = { };
-        data[ "Usage"    ] = 0;
-        chat = chatObject @ data;
+    With[ { chat = chatObject[ MapAt[ Capitalize, KeyMap[ Capitalize ] /@ messages, { All, "Role" } ] ] },
         chat /; MatchQ[ chat, _chatObject ]
     ];
 


### PR DESCRIPTION
Instead of putting a fully resolved `ChatObject[...]` into `Out[...]`, use a delayed evaluation that only constructs the `ChatObject` once when retrieved.

<img width="650" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/e0588995-1418-48a4-8189-0cf110f465a0">
