### PR TITLE
Use lower resolution for images while streaming dynamic output

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -3,7 +3,7 @@
 PacletObject[<|
 	"Name" -> "Wolfram/Chatbook",
 	"PublisherID" -> "Wolfram",
-	"Version" -> "1.0.4",
+	"Version" -> "1.0.5",
 	"WolframVersion" -> "13.2+",
 	"Description" -> "Wolfram Notebooks + LLMs",
 	"License" -> "MIT",


### PR DESCRIPTION
Visually there is not a major difference, but this reduces the traffic over MathLink by a couple of orders of magnitude for images.

# While streaming output
<img width="505" alt="Screenshot 2023-07-21 120947" src="https://github.com/WolframResearch/Chatbook/assets/6674723/1db26914-98d0-4ad2-91e3-7a67a369bb48">

# Final result
<img width="491" alt="Screenshot 2023-07-21 121021" src="https://github.com/WolframResearch/Chatbook/assets/6674723/4ed5156b-0c38-4f77-ad4f-7f23b28aacb7">
