### PR TITLE
Fix formatting of code blocks that have spaces in the language specification

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -398,7 +398,7 @@ fancyTooltip[ expr_, tooltip_ ] := Tooltip[
 (*$textDataFormatRules*)
 $textDataFormatRules = {
     StringExpression[
-        Longest[ "```" ~~ language: Except[ WhitespaceCharacter ]... ] ~~ (" "...) ~~ "\n",
+        Longest[ "```" ~~ language: Except[ "\n" ]... ] ~~ (" "...) ~~ "\n",
         Shortest[ code__ ],
         ("```"|EndOfString)
     ] /; StringFreeQ[ code, "TOOLCALL:" ~~ ___ ~~ ("ENDTOOLCALL"|EndOfString) ] :>
@@ -433,7 +433,7 @@ $textDataFormatRules = {
 $dynamicSplitRules = {
     (* Code blocks *)
     s: StringExpression[
-        Longest[ "```" ~~ language: Except[ WhitespaceCharacter ]... ] ~~ (" "...) ~~ "\n",
+        Longest[ "```" ~~ language: Except[ "\n" ]... ] ~~ (" "...) ~~ "\n",
         Shortest[ code__ ],
         "```"
     ] /; StringFreeQ[ code, "TOOLCALL:" ~~ ___ ~~ ("ENDTOOLCALL"|EndOfString) ] :> s


### PR DESCRIPTION
<img width="635" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/bc150bdd-f5c8-4ba0-98a4-5b610e008d29">
