### PR TITLE
Ensure stylesheet from most recent paclet version is used

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -29,6 +29,12 @@ Cell[
 ]
 
 
+Cell[
+    StyleData[ "ChatStyleSheetInformation" ],
+    TaggingRules -> <| "StyleSheetVersion" -> $stylesheetVersion |>
+]
+
+
 
 (* ::Section::Closed:: *)
 (*Text*)

--- a/Developer/StylesheetBuilder.wl
+++ b/Developer/StylesheetBuilder.wl
@@ -451,6 +451,19 @@ insertionPointMenuItem[ icon_, label_, shortcut_, style_ ] :=
     ] :> FrontEndTokenExecute[ EvaluationNotebook[ ], "Style", style ];
 
 
+
+(* ::Subsection::Closed:: *)
+(*Stylesheet Version*)
+
+
+$stylesheetVersion = StringJoin[
+    PacletObject[ File[ $pacletDirectory ] ][ "Version" ],
+    ".",
+    ToString @ Round @ AbsoluteTime[ ]
+];
+
+
+
 (* ::Subsection::Closed:: *)
 (*inlineResources*)
 

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -1142,6 +1142,10 @@ Notebook[
    |>
   ],
   Cell[
+   StyleData["ChatStyleSheetInformation"],
+   TaggingRules -> <|"StyleSheetVersion" -> "1.0.5.3899183259"|>
+  ],
+  Cell[
    StyleData["Text"],
    ContextMenu -> {
     MenuItem[

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -38,6 +38,6 @@ PacletObject[<|
 				"Birdnardo"
 			}
 		},
-		{"FrontEnd"}
+		{"FrontEnd", "Prepend" -> True}
 	}
 |>]

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -502,9 +502,10 @@ $bugReportStack := StringRiffle[
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*$settings*)
-$settings := Module[ { settings, assoc },
-    settings = CurrentValue @ { TaggingRules, "ChatNotebookSettings" };
-    assoc = Association @ settings;
+$settings := Module[ { settings, styleInfo, assoc },
+    settings  = CurrentValue @ { TaggingRules, "ChatNotebookSettings" };
+    styleInfo = CurrentValue @ { StyleDefinitions, "ChatStyleSheetInformation", TaggingRules };
+    assoc     = Association @ Select[ Association /@ { settings, styleInfo }, AssociationQ ];
     If[ AssociationQ @ assoc,
         KeyDrop[ assoc, "OpenAIKey" ],
         settings


### PR DESCRIPTION
This adds the `"Prepend" -> True` rule to the FrontEnd extension so that the stylesheet from the newest installed version of the paclet will be used instead of what's in the layout.

I've also added version numbers to built stylesheets that will be included in the debug data for internal failures, just to verify that the correct stylesheet is actually being used.