### PR TITLE
Sandbox evaluator improvements

### DIFF
--- a/Source/Chatbook/CreateChatNotebook.wl
+++ b/Source/Chatbook/CreateChatNotebook.wl
@@ -38,6 +38,7 @@ CreateChatNotebook // Options = {
     "ShowMinimized"                     -> Automatic,
     "StreamingOutputMethod"             -> Automatic,
     "Temperature"                       -> 0.7,
+    "ToolOptions"                       :> $DefaultToolOptions,
     "Tools"                             -> Automatic,
     "ToolsEnabled"                      -> Automatic,
     "TopP"                              -> 1

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -15,6 +15,7 @@ Begin[ "`Private`" ];
 
 Needs[ "Wolfram`Chatbook`Common`" ];
 Needs[ "Wolfram`Chatbook`Tools`"  ];
+Needs[ "Wolfram`Chatbook`Utils`"  ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -384,12 +385,12 @@ sandboxResultString[ HoldComplete[ KeyValuePattern @ { "Line" -> line_, "Result"
     ];
 
 sandboxResultString[ HoldComplete[ ___, expr_? simpleResultQ ] ] :=
-    With[ { string = ToString[ Unevaluated @ expr, InputForm, PageWidth -> 100 ] },
+    With[ { string = fixLineEndings @ ToString[ Unevaluated @ expr, InputForm, PageWidth -> 100 ] },
         If[ StringLength @ string < $toolResultStringLength,
             If[ StringContainsQ[ string, "\n" ], "\n" <> string, string ],
             StringJoin[
                 "\n",
-                ToString[
+                fixLineEndings @ ToString[
                     Unevaluated @ Short[ expr, 5 ],
                     OutputForm,
                     PageWidth -> 100

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -119,7 +119,7 @@ pingSandboxKernel // endDefinition;
 startSandboxKernel // beginDefinition;
 
 startSandboxKernel[ ] := Enclose[
-    Module[ { pwFile, kernel, pid },
+    Module[ { pwFile, kernel, readPaths, pid },
 
         Scan[ LinkClose, Select[ Links[ ], sandboxKernelQ ] ];
 
@@ -127,8 +127,21 @@ startSandboxKernel[ ] := Enclose[
 
         kernel = ConfirmMatch[ LinkLaunch @ $sandboxKernelCommandLine, _LinkObject, "LinkLaunch" ];
 
+        readPaths = Replace[
+            $toolOptions[ "WolframLanguageEvaluator", "AllowedReadPaths" ],
+            _Missing :> $DefaultToolOptions[ "WolframLanguageEvaluator", "AllowedReadPaths" ]
+        ];
+
         (* Use StartProtectedMode instead of passing the -sandbox argument, since we need to initialize the FE first *)
-        LinkWrite[ kernel, Unevaluated @ EvaluatePacket[ UsingFrontEnd @ Null; Developer`StartProtectedMode[ ] ] ];
+        With[ { read = $resolvedReadPaths = makePaths @ readPaths },
+            LinkWrite[
+                kernel,
+                Unevaluated @ EvaluatePacket[
+                    UsingFrontEnd @ Null;
+                    Developer`StartProtectedMode[ "Read" -> read ]
+                ]
+            ]
+        ];
 
         pid = pingSandboxKernel @ kernel;
 
@@ -164,6 +177,17 @@ startSandboxKernel[ ] := Enclose[
 ];
 
 startSandboxKernel // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makePaths*)
+makePaths // beginDefinition;
+makePaths[ All ] := If[ $OperatingSystem === "Windows", # <> ":\\" & /@ CharacterRange[ "A", "Z" ], "/" ];
+makePaths[ None ] := { };
+makePaths[ paths_List ] := DeleteDuplicates @ Flatten[ makePaths /@ paths ];
+makePaths[ path_String ] := path;
+makePaths[ Automatic|Inherited|_Missing ] := Automatic;
+makePaths // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -360,12 +384,17 @@ sandboxResultString[ HoldComplete[ KeyValuePattern @ { "Line" -> line_, "Result"
     ];
 
 sandboxResultString[ HoldComplete[ ___, expr_? simpleResultQ ] ] :=
-    With[ { string = ToString[ Unevaluated @ expr, InputForm, PageWidth -> 80 ] },
-        If[ StringLength @ string < 150,
+    With[ { string = ToString[ Unevaluated @ expr, InputForm, PageWidth -> 100 ] },
+        If[ StringLength @ string < $toolResultStringLength,
             If[ StringContainsQ[ string, "\n" ], "\n" <> string, string ],
             StringJoin[
                 "\n",
-                ToString[ Unevaluated @ Short[ expr, 1 ], OutputForm, PageWidth -> 80 ], "\n\n\n",
+                ToString[
+                    Unevaluated @ Short[ expr, Ceiling[ $toolResultStringLength/5 ] ],
+                    OutputForm,
+                    PageWidth -> 100
+                ],
+                "\n\n\n",
                 makeExpressionURI[ "expression", "Formatted Result", Unevaluated @ expr ]
             ]
         ]

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -390,7 +390,7 @@ sandboxResultString[ HoldComplete[ ___, expr_? simpleResultQ ] ] :=
             StringJoin[
                 "\n",
                 ToString[
-                    Unevaluated @ Short[ expr, Ceiling[ $toolResultStringLength/5 ] ],
+                    Unevaluated @ Short[ expr, 5 ],
                     OutputForm,
                     PageWidth -> 100
                 ],

--- a/Source/Chatbook/Tools.wl
+++ b/Source/Chatbook/Tools.wl
@@ -1239,7 +1239,7 @@ makeToolResponseString[ expr_? simpleResultQ ] :=
             StringJoin[
                 "\n",
                 ToString[
-                    Unevaluated @ Short[ expr, Ceiling[ $toolResultStringLength/5 ] ],
+                    Unevaluated @ Short[ expr, 5 ],
                     OutputForm,
                     PageWidth -> 100
                 ],

--- a/Source/Chatbook/Tools.wl
+++ b/Source/Chatbook/Tools.wl
@@ -304,7 +304,7 @@ $toolPost := "
 
 To call a tool, write the following on a new line at any time during your response:
 
-```
+
 TOOLCALL: <tool name>
 {
 	\"<parameter name 1>\": <value 1>
@@ -312,7 +312,7 @@ TOOLCALL: <tool name>
 }
 ENDARGUMENTS
 ENDTOOLCALL
-```
+
 
 The system will execute the requested tool call and you will receive a system message containing the result.
 

--- a/Source/Chatbook/Tools.wl
+++ b/Source/Chatbook/Tools.wl
@@ -1233,12 +1233,12 @@ getAttachment // endDefinition;
 makeToolResponseString // beginDefinition;
 
 makeToolResponseString[ expr_? simpleResultQ ] :=
-    With[ { string = TextString @ expr },
+    With[ { string = fixLineEndings @ TextString @ expr },
         If[ StringLength @ string < $toolResultStringLength,
             If[ StringContainsQ[ string, "\n" ], "\n" <> string, string ],
             StringJoin[
                 "\n",
-                ToString[
+                fixLineEndings @ ToString[
                     Unevaluated @ Short[ expr, 5 ],
                     OutputForm,
                     PageWidth -> 100

--- a/Source/Chatbook/Utils.wl
+++ b/Source/Chatbook/Utils.wl
@@ -8,6 +8,7 @@
 BeginPackage["Wolfram`Chatbook`Utils`"]
 
 `associationKeyDeflatten;
+`fixLineEndings;
 
 CellPrint2
 
@@ -95,6 +96,13 @@ FirstMatchingPositionOrder[patterns_?ListQ][a_, b_] := Module[{
 (*AssociationKeyDeflatten*)
 (* https://resources.wolframcloud.com/FunctionRepository/resources/AssociationKeyDeflatten *)
 importResourceFunction[ associationKeyDeflatten, "AssociationKeyDeflatten" ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*fixLineEndings*)
+fixLineEndings // beginDefinition;
+fixLineEndings[ string_String? StringQ ] := StringReplace[ string, "\r\n" -> "\n" ];
+fixLineEndings // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)


### PR DESCRIPTION
* Allow reading local files by default
* Added "ToolOptions" to chat settings which can override this
* Added `SetToolOptions` as a convenient way to set these options
* Increased the size of string outputs before `Short` will start dropping content

The overall experience is a bit better when asking the LLM to analyze data from files now:
<img width="662" alt="Screenshot 2023-07-24 175343" src="https://github.com/WolframResearch/Chatbook/assets/6674723/c3034f1d-0ed4-4829-b7f5-874b1de00a17">

It will still often claim that it cannot read files, so there's still some prompting work to do.

## Customizing read permissions

```
SetToolOptions["WolframLanguageEvaluator",  "AllowedReadPaths" -> paths]
SetToolOptions[scope, "WolframLanguageEvaluator",  "AllowedReadPaths" -> paths]
```

The value for `scope` can be a front end object, e.g. `$FrontEnd`, `$FrontEndSession`, `CellObject[...]`, etc. If omitted, `$FrontEnd` is used as the scope.

The value for `paths` can be any of the following:

| Value | Description |
| ------ | ------------ |
| All | allow reading from any file |
| Automatic | only allow reading from default locations (temporary directory, installation directory, etc) |
| None | do not allow reading of any local files |
| "path" | allow a specific path |
| {spec1, spec2, ...} | multiple specifications |