### PR TITLE
Fix large input throwing an internal error when assistance is enabled

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -3,7 +3,7 @@
 PacletObject[<|
 	"Name" -> "Wolfram/Chatbook",
 	"PublisherID" -> "Wolfram",
-	"Version" -> "1.1.1",
+	"Version" -> "1.1.2",
 	"WolframVersion" -> "13.2+",
 	"Description" -> "Wolfram Notebooks + LLMs",
 	"License" -> "MIT",

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -1496,6 +1496,7 @@ toolResponseString // endDefinition;
 (*toolFreeQ*)
 toolFreeQ // beginDefinition;
 toolFreeQ[ KeyValuePattern[ "FullContent" -> s_ ] ] := toolFreeQ @ s;
+toolFreeQ[ _ProgressIndicator ] := True;
 toolFreeQ[ s_String ] := ! MatchQ[ toolRequestParser @ s, { _, _LLMToolRequest|_Failure } ];
 toolFreeQ // endDefinition;
 


### PR DESCRIPTION
This now displays the correct error message:
![LargeInputError2](https://github.com/WolframResearch/Chatbook/assets/6674723/56352706-b6e5-4bd2-aaf8-960ca97903a7)
