### PR TITLE
Support excluding cells via options

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -2099,7 +2099,7 @@ selectChatCells0[ cell_, cells: { __CellObject }, final_ ] := Enclose[
         selectedRange = Reverse @ Take[ before, groupPos ];
 
         (* Filter out ignored cells *)
-        filtered = DeleteCases[ selectedRange, KeyValuePattern[ "Style" -> $$chatIgnoredStyle ] ];
+        filtered = ConfirmMatch[ filterChatCells @ selectedRange, { ___Association }, "FilteredCellInfo" ];
 
         (* Delete output cells that come after the evaluation cell *)
         rest = deleteExistingChatOutputs @ Drop[ cellData, cellPosition ];
@@ -2122,6 +2122,30 @@ selectChatCells0[ cell_, cells: { __CellObject }, final_ ] := Enclose[
 ];
 
 selectChatCells0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*filterChatCells*)
+filterChatCells // beginDefinition;
+
+filterChatCells[ cellInfo: { ___Association } ] := Enclose[
+    Module[ { styleExcluded, cells, exclusions },
+
+        styleExcluded = DeleteCases[ cellInfo, KeyValuePattern[ "Style" -> $$chatIgnoredStyle ] ];
+        cells = ConfirmMatch[ styleExcluded[[ All, "CellObject" ]], { ___CellObject }, "CellObjects" ];
+
+        exclusions = ConfirmBy[
+            CurrentValue[ cells, { TaggingRules, "ChatNotebookSettings", "ExcludeFromChat" } ],
+            Length @ # === Length @ styleExcluded &,
+            "Exclusions"
+        ];
+
+        ConfirmMatch[ Pick[ styleExcluded, Not@*TrueQ /@ exclusions ], { ___Association }, "PickCells" ]
+    ],
+    throwInternalFailure[ filterChatCells @ cellInfo, ## ] &
+];
+
+filterChatCells // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)


### PR DESCRIPTION
Here's an example of a notebook that excludes all Text cells from chats:
```
NotebookPut @ Notebook[
    {
        Cell[ "This cell is included", "CodeText" ],
        Cell[ "This cell is not included", "Text" ],
        Cell[ "Test message, please ignore", "ChatInput" ]
    },
    StyleDefinitions -> Notebook[
        {
            Cell @ StyleData[ StyleDefinitions -> "Chatbook.nb" ],
            Cell[
                StyleData[ "Text" ],
                TaggingRules -> <| "ChatNotebookSettings" -> <| "ExcludeFromChat" -> True |> |>
            ]
        },
        StyleDefinitions -> "PrivateStylesheetFormatting.nb"
    ]
]
```

<img width="598" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/3d6de379-5cdc-41c9-a795-d54cea3ca9d2">
