### PR TITLE
Fix bug report markdown syntax for associations

### DIFF
--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -585,7 +585,11 @@ associationMarkdown[ data_Association? AssociationQ ] := StringJoin[
                     "| ",
                     ToString @ ToString[ Unevaluated @ k, CharacterEncoding -> "UTF-8" ],
                     " | ``",
-                    truncatePartString @ ToString[ Unevaluated @ v, InputForm, CharacterEncoding -> "UTF-8" ],
+                    escapePipes @ truncatePartString @ ToString[
+                        Unevaluated @ v,
+                        InputForm,
+                        CharacterEncoding -> "UTF-8"
+                    ],
                     "`` |"
                 ],
                 HoldAllComplete
@@ -651,6 +655,11 @@ truncatePartString[ string_String, max_Integer ] :=
     If[ StringLength @ string > max, StringTake[ string, UpTo @ max ] <> "...", string ];
 
 truncatePartString[ other_, max_Integer ] := truncatePartString[ ToString[ Unevaluated @ other, InputForm ], max ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*escapePipes*)
+escapePipes[ string_String ] := StringReplace[ string, "|" -> "\\|" ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -427,13 +427,24 @@ throwInternalFailure // endDefinition;
 (*makeInternalFailureData*)
 makeInternalFailureData // Attributes = { HoldFirst };
 
-makeInternalFailureData[ eval_, Failure[ tag_, as_Association ], args___ ] := maskOpenAIKey @ <|
-    "Evaluation" :> eval,
-    "Failure"    -> Failure[ tag, Association[ KeyTake[ as, "Information" ], as ] ],
-    "Arguments"  -> { args }
-|>;
+makeInternalFailureData[ eval_, Failure[ tag_, as_Association ], args___ ] :=
+    StackInhibit @ Module[ { $stack = Stack[ _ ] },
+        maskOpenAIKey @ <|
+            "Evaluation" :> eval,
+            "Failure"    -> Failure[ tag, Association[ KeyTake[ as, "Information" ], as ] ],
+            "Arguments"  -> { args },
+            "Stack"      :> $stack
+        |>
+    ];
 
-makeInternalFailureData[ eval_, args___ ] := maskOpenAIKey @ <| "Evaluation" :> eval, "Arguments" -> { args } |>;
+makeInternalFailureData[ eval_, args___ ] :=
+    StackInhibit @ Module[ { $stack = Stack[ _ ] },
+        maskOpenAIKey @ <|
+            "Evaluation" :> eval,
+            "Arguments"  -> { args },
+            "Stack"      :> $stack
+        |>
+    ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Dialogs.wl
+++ b/Source/Chatbook/Dialogs.wl
@@ -23,8 +23,6 @@ BeginPackage[ "Wolfram`Chatbook`Dialogs`" ];
 `grayDialogButtonLabel;
 `redDialogButtonLabel;
 
-(* TODO: create a Dialogs.wl file containing definitions to share between this and the persona dialog *)
-
 Begin[ "`Private`" ];
 
 Needs[ "Wolfram`Chatbook`"                   ];


### PR DESCRIPTION
The vertical bar in association syntax needs to be escaped when formatting for markdown tables, since that character is used to separate columns:

<img width="368" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/155c2a22-f1ff-4281-ad54-53df4b1db4d3">
