### PR TITLE
Fix for gear menu appearing persistently in 14.0

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -14,7 +14,7 @@ Cell[
     CellInsertionPointCell -> $cellInsertionPointCell,
 
     CellTrayWidgets -> <|
-        "GearMenu" -> {},
+        "GearMenu"   -> <| "Condition" -> False |>,
         "ChatWidget" -> <|
             "Type"    -> "Focus",
             "Content" -> Cell[ BoxData @ TemplateBox[ { }, "ChatWidgetButton" ], "ChatWidget" ]
@@ -76,7 +76,7 @@ Cell[
 Cell[
     StyleData[ "Output" ],
     ContextMenu -> contextMenu[ $askMenuItem, Delimiter, "Output" ],
-    CellTrayWidgets -> <| "GearMenu" -> {} |>
+    CellTrayWidgets -> <| "GearMenu" -> <| "Condition" -> False |> |>
 ]
 
 
@@ -87,7 +87,7 @@ Cell[
 
 Cell[
     StyleData[ "Message" ],
-    CellTrayWidgets -> <| "GearMenu" -> {} |>
+    CellTrayWidgets -> <| "GearMenu" -> <| "Condition" -> False |> |>
 ]
 
 

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -748,7 +748,7 @@ Notebook[
     ],
    TaggingRules -> <|"ChatNotebookSettings" -> <||>|>,
    CellTrayWidgets -> <|
-    "GearMenu" -> { },
+    "GearMenu" -> <|"Condition" -> False|>,
     "ChatWidget" -> <|
      "Type" -> "Focus",
      "Content" ->
@@ -1143,7 +1143,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.1.4.3904282110"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.2.1.3905399249"|>
   ],
   Cell[
    StyleData["Text"],
@@ -1431,7 +1431,7 @@ Notebook[
   ],
   Cell[
    StyleData["Output"],
-   CellTrayWidgets -> <|"GearMenu" -> {}|>,
+   CellTrayWidgets -> <|"GearMenu" -> <|"Condition" -> False|>|>,
    ContextMenu -> {
     MenuItem[
      "Ask AI Assistant",
@@ -1522,7 +1522,7 @@ Notebook[
   ],
   Cell[
    StyleData["Message"],
-   CellTrayWidgets -> <|"GearMenu" -> {}|>
+   CellTrayWidgets -> <|"GearMenu" -> <|"Condition" -> False|>|>
   ],
   Cell[
    StyleData[


### PR DESCRIPTION
This fixes an issue with the gear menu showing persistently in 14.0:
<img width="640" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/6f39686d-57cb-4ab0-ab77-ee02b6544c52">
