### PR TITLE
Consistent access of tool name

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -632,7 +632,7 @@ parseFullToolCallString[ id_String, resp: HoldPattern[ _LLMToolResponse ], strin
 parseFullToolCallString[ id_String, tool: HoldPattern[ _LLMTool ], parameters_Association, output_, string_ ] :=
     $lastFullParsed = <|
         "ID"                 -> id,
-        "Name"               -> tool[ "Name" ],
+        "Name"               -> toolName[tool],
         "DisplayName"        -> getToolDisplayName @ tool,
         "Icon"               -> getToolIcon @ tool,
         "FormattingFunction" -> getToolFormattingFunction @ tool,


### PR DESCRIPTION
Use the `toolName` utility from elsewhere in the paclet instead of the deprecated LLMTool subvalue access.