### PR TITLE
Change default scope for `CurrentChatSettings` to `$FrontEndSession` …

### DIFF
--- a/Source/Chatbook/FrontEnd.wl
+++ b/Source/Chatbook/FrontEnd.wl
@@ -246,18 +246,7 @@ CurrentChatSettings[ args___ ] :=
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*$currentEvaluationObject*)
-
-(* During asynchronous tasks, EvaluationCell[ ] will return $Failed, so we instead use this to take the first FE object
-   in ascending order of inheritance that we can read settings from. *)
-$currentEvaluationObject := FirstCase[
-    Unevaluated @ {
-        EvaluationCell[ ],
-        EvaluationNotebook[ ],
-        $FrontEndSession
-    },
-    obj_ :> With[ { res = obj }, res /; MatchQ[ res, $$feObj ] ],
-    throwInternalFailure @ $currentEvaluationObject
-];
+$currentEvaluationObject := $FrontEndSession;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
…since there are too many edge cases for `EvaluationCell[]`.

Test case:
```
CreateNotebook[ DockedCells -> { Cell @ BoxData @ ToBoxes @ Button[ "test", Print @ ChatObject[ ], Method -> "Queued" ] } ]
```