### PR TITLE
Minor QoL updates

### DIFF
--- a/Source/Chatbook/CreateChatNotebook.wl
+++ b/Source/Chatbook/CreateChatNotebook.wl
@@ -18,14 +18,19 @@ Needs[ "Wolfram`Chatbook`UI`"         ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*Argument Patterns*)
+$$createChatOptions = OptionsPattern[ { CreateChatNotebook, Notebook } ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*CreateChatNotebook*)
 CreateChatNotebook // Options = Normal[ $defaultChatSettings, Association ];
 
 
-CreateChatNotebook[ opts: OptionsPattern[ { CreateChatNotebook, Notebook } ] ] :=
+CreateChatNotebook[ opts: $$createChatOptions ] :=
     catchMine @ createChatNotebook @ opts;
 
-CreateChatNotebook[ nbo_NotebookObject, opts: OptionsPattern[ { CreateChatNotebook, Notebook } ] ] :=
+CreateChatNotebook[ nbo_NotebookObject, opts: $$createChatOptions ] :=
     catchMine @ Enclose @ Module[ { settings, options },
         settings = makeChatNotebookSettings @ Association @ FilterRules[ { opts }, Options @ CreateChatNotebook ];
         options  = makeChatNotebookOptions[ settings, opts ];
@@ -33,7 +38,13 @@ CreateChatNotebook[ nbo_NotebookObject, opts: OptionsPattern[ { CreateChatNotebo
         nbo
     ];
 
-CreateChatNotebook[ chat: HoldPattern[ _ChatObject ], opts: OptionsPattern[ { CreateChatNotebook, Notebook } ] ] :=
+CreateChatNotebook[ cell_Cell, opts: $$createChatOptions ] :=
+    catchMine @ CreateChatNotebook[ { cell }, opts ];
+
+CreateChatNotebook[ cells: { ___Cell }, opts: $$createChatOptions ] :=
+    catchMine @ Block[ { initialChatCells = cells & }, CreateChatNotebook @ opts ];
+
+CreateChatNotebook[ chat: HoldPattern[ _ChatObject ], opts: $$createChatOptions ] :=
     catchMine @ createNotebookFromChatObject[ chat, opts ];
 
 (* ::**************************************************************************************************************:: *)
@@ -158,7 +169,7 @@ $inlinedStylesheet := $inlinedStylesheet = Import[
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*CreateChatDrivenNotebook*)
-CreateChatDrivenNotebook[ opts: OptionsPattern[ { CreateChatNotebook, Notebook } ] ] :=
+CreateChatDrivenNotebook[ opts: $$createChatOptions ] :=
     catchMine @ CreateChatNotebook[
         "ChatDrivenNotebook" -> True,
         "LLMEvaluator"       -> "PlainChat",

--- a/Source/Chatbook/Main.wl
+++ b/Source/Chatbook/Main.wl
@@ -15,6 +15,7 @@ BeginPackage[ "Wolfram`Chatbook`" ];
 `$DefaultToolOptions;
 `$DefaultTools;
 `$InstalledTools;
+`$SandboxKernel;
 `$ToolFunctions;
 `CellToChatMessage;
 `Chatbook;

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -24,6 +24,7 @@ Needs[ "Wolfram`Chatbook`Utils`"      ];
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Configuration*)
+$SandboxKernel             = None;
 $sandboxPingTimeout       := toolOptionValue[ "WolframLanguageEvaluator", "PingTimeConstraint"       ];
 $sandboxEvaluationTimeout := toolOptionValue[ "WolframLanguageEvaluator", "EvaluationTimeConstraint" ];
 
@@ -186,7 +187,7 @@ startSandboxKernel[ ] := Enclose[
         ];
 
         If[ IntegerQ @ pid,
-            kernel,
+            $SandboxKernel = kernel,
             Quiet @ LinkClose @ kernel;
             throwFailure[ "NoSandboxKernel" ]
         ]


### PR DESCRIPTION
Add support for `CreateChatNotebook[{Cell[...], ...}]` and exposed the sandbox kernel `LinkObject` as `$SandboxKernel`.