### PR TITLE
feat: improve setting ui in UI.wl, add OpenAi Chat Completion URL settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 .DS_Store
 Source/Chatbook/64Bit/Chatbook.mx
+/.idea/zigbrains.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 build
 .DS_Store
 Source/Chatbook/64Bit/Chatbook.mx
-/.idea/zigbrains.xml

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -312,7 +312,7 @@ makeHTTPRequest[ settings_Association? AssociationQ, messages: { __Association }
 
         key         = ConfirmBy[ Lookup[ settings, "OpenAIKey" ], StringQ ];
         stream      = True;
-        apiCompletionURL = ConfirmBy[ Lookup[ settings, "OpenAiApiCompletionURL" ], StringQ ];
+        apiCompletionURL = ConfirmBy[ Lookup[ settings, "OpenAIAPICompletionURL" ], StringQ ];
 
         (* model parameters *)
         model       = Lookup[ settings, "Model"           , $DefaultModel ];

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -308,10 +308,11 @@ makeHTTPRequest // beginDefinition;
 
 (* cSpell: ignore ENDTOOLCALL *)
 makeHTTPRequest[ settings_Association? AssociationQ, messages: { __Association } ] :=
-    Enclose @ Module[ { key, stream, model, tokens, temperature, topP, freqPenalty, presPenalty, data, body },
+    Enclose @ Module[ { key, stream, model, tokens, temperature, topP, freqPenalty, presPenalty, data, body, apiCompletionURL },
 
         key         = ConfirmBy[ Lookup[ settings, "OpenAIKey" ], StringQ ];
         stream      = True;
+        apiCompletionURL = ConfirmBy[ Lookup[ settings, "OpenAiApiCompletionURL" ], StringQ ];
 
         (* model parameters *)
         model       = Lookup[ settings, "Model"           , $DefaultModel ];
@@ -340,7 +341,7 @@ makeHTTPRequest[ settings_Association? AssociationQ, messages: { __Association }
 
         $lastHTTPParameters = data;
         $lastRequest = HTTPRequest[
-            "https://api.openai.com/v1/chat/completions",
+            apiCompletionURL,
             <|
                 "Headers" -> <|
                     "Content-Type"  -> "application/json",

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -44,6 +44,7 @@ $defaultChatSettings = <|
     "Multimodal"                -> Automatic,
     "NotebookWriteMethod"       -> Automatic,
     "OpenAIKey"                 -> Automatic, (* TODO: remove this once LLMServices is widely available *)
+    "OpenAiApiCompletionURL"    -> "https://api.openai.com/v1/chat/completions",
     "PresencePenalty"           -> 0.1,
     "ProcessingFunctions"       :> $DefaultChatProcessingFunctions,
     "Prompts"                   -> { },

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -44,7 +44,7 @@ $defaultChatSettings = <|
     "Multimodal"                -> Automatic,
     "NotebookWriteMethod"       -> Automatic,
     "OpenAIKey"                 -> Automatic, (* TODO: remove this once LLMServices is widely available *)
-    "OpenAiApiCompletionURL"    -> "https://api.openai.com/v1/chat/completions",
+    "OpenAIAPICompletionURL"    -> "https://api.openai.com/v1/chat/completions",
     "PresencePenalty"           -> 0.1,
     "ProcessingFunctions"       :> $DefaultChatProcessingFunctions,
     "Prompts"                   -> { },

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -486,6 +486,13 @@ makeTemperatureSlider[
 		BaseStyle -> { FontSize -> 12 }
 	]
 
+makeOpenAiApiCompletionURLForm[value_]:= Pane[
+	InputField[value,
+		String,
+		ImageSize -> {180, Automatic},
+		BaseStyle -> {FontSize -> 12}]
+]
+
 (*=========================================*)
 (* Common preferences content construction *)
 (*=========================================*)
@@ -601,6 +608,21 @@ makeFrontEndAndNotebookSettingsContent[
 							CurrentValue[
 								targetObj,
 								{TaggingRules, "ChatNotebookSettings", "Temperature"}
+							] = newValue;
+						)
+					]
+				]
+			}, Spacer[3]]},
+
+			{Row[{
+				tr["Default OpenAi Chat Completion Endpoint"],
+				makeOpenAiApiCompletionURLForm[
+					Dynamic[
+						currentChatSettings[targetObj, "OpenAiApiCompletionURL"],
+						newValue |-> (
+							CurrentValue[
+								targetObj,
+								{TaggingRules, "ChatNotebookSettings", "OpenAiApiCompletionURL"}
 							] = newValue;
 						)
 					]

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -489,7 +489,7 @@ makeTemperatureSlider[
 makeOpenAiApiCompletionURLForm[value_]:= Pane[
 	InputField[value,
 		String,
-		ImageSize -> {180, Automatic},
+		ImageSize -> {240, Automatic},
 		BaseStyle -> {FontSize -> 12}]
 ]
 
@@ -615,7 +615,7 @@ makeFrontEndAndNotebookSettingsContent[
 			}, Spacer[3]]},
 
 			{Row[{
-				tr["Default OpenAi Chat Completion Endpoint"],
+				tr["Chat Completion URL:"],
 				makeOpenAiApiCompletionURLForm[
 					Dynamic[
 						currentChatSettings[targetObj, "OpenAiApiCompletionURL"],

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -486,7 +486,7 @@ makeTemperatureSlider[
 		BaseStyle -> { FontSize -> 12 }
 	]
 
-makeOpenAiApiCompletionURLForm[value_]:= Pane[
+makeOpenAIAPICompletionURLForm[value_]:= Pane[
 	InputField[value,
 		String,
 		ImageSize -> {240, Automatic},
@@ -616,13 +616,13 @@ makeFrontEndAndNotebookSettingsContent[
 
 			{Row[{
 				tr["Chat Completion URL:"],
-				makeOpenAiApiCompletionURLForm[
+				makeOpenAIAPICompletionURLForm[
 					Dynamic[
-						currentChatSettings[targetObj, "OpenAiApiCompletionURL"],
+						currentChatSettings[targetObj, "OpenAIAPICompletionURL"],
 						newValue |-> (
 							CurrentValue[
 								targetObj,
-								{TaggingRules, "ChatNotebookSettings", "OpenAiApiCompletionURL"}
+								{TaggingRules, "ChatNotebookSettings", "OpenAIAPICompletionURL"}
 							] = newValue;
 						)
 					]


### PR DESCRIPTION
```txt
Now you can change the default endpoint to anything you want. 
```

Hello, this repo is pretty big, I try not to mess with the  current code base but if I do something wrong, feel free to fix it if you have time 

There are typical cases in which the user didn't fetch data from the official OpenAi url but from some kind of proxy, that is why I added this minor change.

![image](https://github.com/WolframResearch/Chatbook/assets/69144096/8506cc62-d9eb-4e4b-b8f1-8722fa0f4902)

By default, the official URL will be used, but now people can freely change it to something else like `http://localhost:8080/v1/chat/completions/`. 






