### PR TITLE
Bugfix: Workaround for multi-line code blocks not parsing correctly in cloud notebooks

### DIFF
--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -1161,7 +1161,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.3.4.3910935567"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.3.6.3913177292"|>
   ],
   Cell[
    StyleData["Text"],

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -1,7 +1,7 @@
 PacletObject[ <|
     "Name"           -> "Wolfram/Chatbook",
     "PublisherID"    -> "Wolfram",
-    "Version"        -> "1.3.5",
+    "Version"        -> "1.3.6",
     "WolframVersion" -> "13.3+",
     "Description"    -> "Wolfram Notebooks + LLMs",
     "License"        -> "MIT",

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -453,7 +453,7 @@ insertCodeBelow[ cell_Cell, evaluate_ ] :=
     ];
 
 insertCodeBelow[ string_String, evaluate_ ] :=
-    insertCodeBelow[ Cell[ BoxData @ string, "Input" ], evaluate ];
+    insertCodeBelow[ reparseCodeBoxes @ Cell[ BoxData @ string, "Input" ], evaluate ];
 
 insertCodeBelow // endDefinition;
 

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -491,7 +491,7 @@ getCodeBlockContent[ TemplateBox[ { boxes_ }, "ChatCodeBlockTemplate", ___ ] ] :
 getCodeBlockContent[ Cell[ BoxData[ boxes_, ___ ] ] ] := getCodeBlockContent @ boxes;
 getCodeBlockContent[ DynamicModuleBox[ _, boxes_, ___ ] ] := getCodeBlockContent @ boxes;
 getCodeBlockContent[ TagBox[ boxes_, _EventHandlerTag, ___ ] ] := getCodeBlockContent @ boxes;
-getCodeBlockContent[ Cell[ boxes_, "ChatCode", "Input", ___ ] ] := Cell[ boxes, "Input" ];
+getCodeBlockContent[ Cell[ boxes_, "ChatCode", "Input", ___ ] ] := reparseCodeBoxes @ Cell[ boxes, "Input" ];
 
 getCodeBlockContent[ Cell[ boxes_, "ExternalLanguage", ___, CellEvaluationLanguage -> lang_, ___ ] ] :=
     Cell[ boxes, "ExternalLanguage", CellEvaluationLanguage -> lang ];
@@ -499,6 +499,19 @@ getCodeBlockContent[ Cell[ boxes_, "ExternalLanguage", ___, CellEvaluationLangua
 getCodeBlockContent[ cell: Cell[ _, _String, ___ ] ] := cell;
 
 getCodeBlockContent // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*reparseCodeBoxes*)
+reparseCodeBoxes // beginDefinition;
+
+reparseCodeBoxes[ Cell[ BoxData[ s_String ], a___ ] ] /; $cloudNotebooks :=
+    Cell[ BoxData @ UsingFrontEnd @ stringToBoxes @ s, a ];
+
+reparseCodeBoxes[ cell_Cell ] :=
+    cell;
+
+reparseCodeBoxes // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
# Before
<img width="674" alt="Screenshot 2024-01-02 093325" src="https://github.com/WolframResearch/Chatbook/assets/6674723/337bf637-0490-4abb-98f7-b52746a7e68d">

# After
<img width="621" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/25d218cc-8346-49e5-a924-79b8bd0ddb36">
