### PR TITLE
Bugfix: Fix the missing disable button when auto assistance outputs are first created

### DIFF
--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -2297,14 +2297,7 @@ attachChatOutputMenu[ cell_CellObject ] /; $cloudNotebooks := Null;
 
 attachChatOutputMenu[ cell_CellObject ] := (
     $lastChatOutput = cell;
-    NotebookDelete @ Cells[ cell, AttachedCell -> True, CellStyle -> "ChatMenu" ];
-    AttachCell[
-        cell,
-        Cell[ BoxData @ TemplateBox[ { "ChatOutput", RGBColor[ "#ecf0f5" ] }, "ChatMenuButton" ], "ChatMenu" ],
-        { Right, Top },
-        Offset[ { -7, -7 }, { Right, Top } ],
-        { Right, Top }
-    ]
+    Block[ { EvaluationCell = cell & }, CurrentValue[ cell, Initialization ] ]
 );
 
 attachChatOutputMenu // endDefinition;


### PR DESCRIPTION
# Before
![AssistantCellInitialization](https://github.com/WolframResearch/Chatbook/assets/6674723/cb99474a-6648-4052-b05b-8499df8ca225)

# After
![Issue299Fixed](https://github.com/WolframResearch/Chatbook/assets/6674723/fd05a97a-07ea-48d4-a8ad-c4e1dca12ae9)
