### PR TITLE
Bugfix: Return `Null` instead of generating an internal failure if the current chat input is excluded

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -392,7 +392,10 @@ EvaluateChatInput // beginDefinition;
 EvaluateChatInput[ ] := EvaluateChatInput @ rootEvaluationCell[ ];
 
 EvaluateChatInput[ evalCell_CellObject? chatInputCellQ ] :=
-    EvaluateChatInput[ evalCell, parentNotebook @ evalCell ];
+    If[ chatExcludedQ @ evalCell,
+        Null,
+        EvaluateChatInput[ evalCell, parentNotebook @ evalCell ]
+    ];
 
 EvaluateChatInput[ source: _CellObject | $Failed ] :=
     With[ { evalCell = rootEvaluationCell @ source },
@@ -1034,7 +1037,7 @@ SendChat // beginDefinition;
 
 SendChat[ ] := SendChat @ rootEvaluationCell[ ];
 
-SendChat[ evalCell_CellObject, ___ ] /; MemberQ[ CurrentValue[ evalCell, CellStyle ], "ChatExcluded" ] := Null;
+SendChat[ evalCell_CellObject? chatExcludedQ, ___ ] := Null;
 
 SendChat[ evalCell_CellObject ] := SendChat[ evalCell, parentNotebook @ evalCell ];
 

--- a/Source/Chatbook/ChatHistory.wl
+++ b/Source/Chatbook/ChatHistory.wl
@@ -6,6 +6,7 @@ BeginPackage[ "Wolfram`Chatbook`ChatHistory`" ];
 
 HoldComplete[
     `accentIncludedCells;
+    `chatExcludedQ;
     `extraCellHeight;
     `filterChatCells;
     `getCellsInChatHistory;
@@ -172,24 +173,27 @@ selectChatHistoryCells // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*chatExcludedQ*)
+chatExcludedQ // beginDefinition;
+
+chatExcludedQ[ cell_CellObject ] := chatExcludedQ @ cellInformation @ cell;
+
+chatExcludedQ[ Cell[ __, $$chatIgnoredStyle, ___ ] ] := True;
+chatExcludedQ[ Cell[ __, TaggingRules -> tags_, ___ ] ] := chatExcludedQ @ tags;
+chatExcludedQ[ Cell[ ___ ] ] := False;
+
+chatExcludedQ[ KeyValuePattern[ "Style" -> $$chatIgnoredStyle ] ] := True;
+chatExcludedQ[ KeyValuePattern[ "ChatNotebookSettings" -> settings_ ] ] := chatExcludedQ @ settings;
+chatExcludedQ[ KeyValuePattern[ "ExcludeFromChat" -> exclude_ ] ] := TrueQ @ exclude;
+chatExcludedQ[ KeyValuePattern[ { } ] ] := False;
+
+chatExcludedQ // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*filterChatCells*)
 filterChatCells // beginDefinition;
-
-filterChatCells[ cellInfo: { ___Association } ] := Enclose[
-    Module[ { styleExcluded, tagExcluded, cells },
-
-        styleExcluded = DeleteCases[ cellInfo, KeyValuePattern[ "Style" -> $$chatIgnoredStyle ] ];
-
-        tagExcluded = DeleteCases[
-            styleExcluded,
-            KeyValuePattern[ "ChatNotebookSettings" -> KeyValuePattern[ "ExcludeFromChat" -> True ] ]
-        ];
-
-        tagExcluded
-    ],
-    throwInternalFailure[ filterChatCells @ cellInfo, ## ] &
-];
-
+filterChatCells[ cellInfo: { ___Association } ] := Select[ cellInfo, Not @* chatExcludedQ ];
 filterChatCells // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1120,6 +1120,9 @@ selectChatCells0[ cell_, cells: { __CellObject }, final_ ] := Enclose[
         (* Filter out ignored cells *)
         filtered = ConfirmMatch[ filterChatCells @ selectedRange, { ___Association }, "FilteredCellInfo" ];
 
+        (* If all cells are excluded, do nothing *)
+        If[ filtered === { }, throwTop @ Null ];
+
         (* Delete output cells that come after the evaluation cell *)
         rest = deleteExistingChatOutputs @ Drop[ cellData, cellPosition ];
 


### PR DESCRIPTION
This would previously yield an internal error:
![image](https://github.com/WolframResearch/Chatbook/assets/6674723/5643bf92-d663-4c6c-ab88-9af15d27c09d)

It now just returns `Null` instead.