### PR TITLE
Bugfix: Avoid messages that occur during bad caching of tool response boxes

### DIFF
--- a/Source/Chatbook/FrontEnd.wl
+++ b/Source/Chatbook/FrontEnd.wl
@@ -592,7 +592,7 @@ compressRasterBoxes // endDefinition;
 (* Effectively equivalent to OpenerView, except strips out the unnecessary interpretation information, and compresses
    the hidden part if it's very large.
 *)
-openerView[ args___ ] := openerView[ args ] = openerView0[ args ];
+openerView[ args___ ] := Verbatim[ openerView[ args ] ] = openerView0[ args ];
 
 openerView0 // beginDefinition;
 openerView0[ { a_, b_ }, args___ ] /; ByteCount @ b > 50000 := openerView1[ { a, compressUntilViewed @ b }, args ];


### PR DESCRIPTION
Tool responses that contain patterns would issue messages during caching of `openerView`:
<img width="709" alt="Screenshot 2024-01-02 121441" src="https://github.com/WolframResearch/Chatbook/assets/6674723/694540e7-cf44-4c87-a2e2-19dab2b93d8c">

This fixes that by wrapping the arguments in `Verbatim` when caching the result.