### PR TITLE
Feature: MaxContextTokens can be set to `Infinity` to avoid truncation

### DIFF
--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -217,11 +217,13 @@ makeChatMessages[ settings_, cells_ ] :=
             $multimodalMessages = TrueQ @ settings[ "Multimodal" ],
             $tokenBudget        = settings[ "MaxContextTokens" ],
             $tokenPressure      = 0.0,
-            $cellStringBudget   = Replace[
+            $initialCellStringBudget = Replace[
                 settings[ "MaxCellStringLength" ],
                 Except[ $$size ] -> $defaultMaxCellStringLength
-            ]
+            ],
+            $cellStringBudget
         },
+        $cellStringBudget = $initialCellStringBudget;
         If[ settings[ "BasePrompt" ] =!= None, tokenCheckedMessage[ settings, $fullBasePrompt ] ];
         (* FIXME: need to account for persona/tool prompting as well *)
         makeChatMessages0[ settings, cells ]
@@ -245,10 +247,6 @@ makeChatMessages0[ settings0_, cells_List ] := Enclose[
         toMessage0 = Confirm[ getCellMessageFunction @ settings, "CellMessageFunction" ];
 
         $tokenBudgetLog = Internal`Bag[ ];
-        $initialCellStringBudget = Replace[
-            settings[ "MaxCellStringLength" ],
-            Except[ $$size ] -> $defaultMaxCellStringLength
-        ];
 
         toMessage = Function @ With[
             { msg = toMessage0[ #1, <| #2, "TokenBudget" -> $tokenBudget, "TokenPressure" -> $tokenPressure |> ] },

--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -216,7 +216,11 @@ makeChatMessages[ settings_, cells_ ] :=
         {
             $multimodalMessages = TrueQ @ settings[ "Multimodal" ],
             $tokenBudget        = settings[ "MaxContextTokens" ],
-            $tokenPressure      = 0.0
+            $tokenPressure      = 0.0,
+            $cellStringBudget   = Replace[
+                settings[ "MaxCellStringLength" ],
+                Except[ $$size ] -> $defaultMaxCellStringLength
+            ]
         },
         If[ settings[ "BasePrompt" ] =!= None, tokenCheckedMessage[ settings, $fullBasePrompt ] ];
         (* FIXME: need to account for persona/tool prompting as well *)
@@ -303,6 +307,8 @@ combineExcisedMessages // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*tokenCheckedMessage*)
 tokenCheckedMessage // beginDefinition;
+
+tokenCheckedMessage[ as_Association, message_ ] /; $cellStringBudget === Infinity := message;
 
 tokenCheckedMessage[ as_Association, message_ ] := Enclose[
     Catch @ Module[ { count, budget, resized },

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1301,6 +1301,7 @@ $autoSettingKeyPriority := Enclose[
 (* FIXME: need to hook into token pressure to gradually decrease limits *)
 chooseMaxCellStringLength // beginDefinition;
 chooseMaxCellStringLength[ as_Association ] := chooseMaxCellStringLength[ as, as[ "MaxContextTokens" ] ];
+chooseMaxCellStringLength[ as_, Infinity ] := Infinity;
 chooseMaxCellStringLength[ as_, tokens: $$size ] := Ceiling[ $defaultMaxCellStringLength * tokens / 2^13 ];
 chooseMaxCellStringLength // endDefinition;
 


### PR DESCRIPTION
This is useful if you'd rather get a `Failure[...]` instead of sending chat with less content than you expected:
```
NotebookEvaluate[
    CreateChatNotebook[
        { Cell[ ResourceData[ "Alice in Wonderland" ], "Text" ], Cell[ "What's that?", "ChatInput" ] },
        "MaxContextTokens" -> Infinity
    ],
    InsertResults -> True
]
```

<img width="665" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/1db5071b-3cd6-4fb9-9d64-1be09ebb9d74">
