### PR TITLE
Bugfix: Exploding cells failure when there's a language-agnostic code block

### DIFF
--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -1161,7 +1161,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.3.6.3913177292"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.3.7.3913365950"|>
   ],
   Cell[
    StyleData["Text"],

--- a/Source/Chatbook/Explode.wl
+++ b/Source/Chatbook/Explode.wl
@@ -9,7 +9,7 @@ Begin[ "`Private`" ];
 Needs[ "Wolfram`Chatbook`"        ];
 Needs[ "Wolfram`Chatbook`Common`" ];
 
-$$newCellStyle = "Section"|"Subsection"|"Subsubsection"|"Subsubsubsection"|"Item"|"Input"|"ExternalLanguage";
+$$newCellStyle = "Section"|"Subsection"|"Subsubsection"|"Subsubsubsection"|"Item"|"Input"|"ExternalLanguage"|"Program";
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -69,6 +69,9 @@ $preprocessingRules := $preprocessingRules = Dispatch @ {
 
     (* Remove "ChatCodeBlock" styling: *)
     Cell[ BoxData[ cell_Cell, ___ ], "ChatCodeBlock", ___ ] :> cell,
+
+    (* Language-agnostic code blocks: *)
+    Cell[ text_, "ChatPreformatted", ___ ] :> Cell[ text, "Program" ],
 
     (* Remove "ChatCodeBlockTemplate" template boxes: *)
     TemplateBox[ { cell_Cell }, "ChatCodeBlockTemplate" ] :> cell,


### PR DESCRIPTION
# Before
<img width="657" alt="Screenshot 2024-01-04 134856" src="https://github.com/WolframResearch/Chatbook/assets/6674723/653d707a-3402-438e-96ce-bd8e7e97b36c">

# After
<img width="656" alt="Screenshot 2024-01-04 135855" src="https://github.com/WolframResearch/Chatbook/assets/6674723/63d71f08-61af-40dc-8c34-445a070fe0a4">
