### PR TITLE
Stop chat if there's a user abort

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -1,7 +1,7 @@
 PacletObject[ <|
     "Name"           -> "Wolfram/Chatbook",
     "PublisherID"    -> "Wolfram",
-    "Version"        -> "1.4.0",
+    "Version"        -> "1.4.1",
     "WolframVersion" -> "13.3+",
     "Description"    -> "Wolfram Notebooks + LLMs",
     "License"        -> "MIT",

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -417,7 +417,7 @@ EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject, settings_Association
 
         (* Send chat while listening for an abort: *)
         CheckAbort[
-        sendChat[ evalCell, nbo, settings ];
+            sendChat[ evalCell, nbo, settings ];
             waitForLastTask[ ]
             ,
             (* The user has issued an abort: *)
@@ -442,17 +442,30 @@ EvaluateChatInput[ evalCell_CellObject, nbo_NotebookObject, settings_Association
                             <| "Role" -> "Assistant", "Content" -> $lastChatString |>
                         ]
                     },
-                    applyHandlerFunction[ settings, "ChatPost", <| "ChatObject" -> chat, "NotebookObject" -> nbo |> ];
-                    Sow[ chat, $chatObjectTag ]
+                    applyChatPost[ chat, settings, nbo, $aborted ]
                 ],
-                applyHandlerFunction[ settings, "ChatPost", <| "ChatObject" -> None, "NotebookObject" -> nbo |> ];
-                Sow[ None, $chatObjectTag ];
+                applyChatPost[ None, settings, nbo, $aborted ];
                 Null
             ];
         ]
     ];
 
 EvaluateChatInput // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*applyChatPost*)
+applyChatPost // beginDefinition;
+
+applyChatPost[ chat_, settings_, nbo_, aborted: True|False ] := (
+    If[ aborted,
+        applyHandlerFunction[ settings, "ChatAbort", <| "ChatObject" -> chat, "NotebookObject" -> nbo |> ],
+        applyHandlerFunction[ settings, "ChatPost" , <| "ChatObject" -> chat, "NotebookObject" -> nbo |> ]
+    ];
+    Sow[ chat, $chatObjectTag ]
+);
+
+applyChatPost // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Source/Chatbook/Main.wl
+++ b/Source/Chatbook/Main.wl
@@ -7,6 +7,7 @@ BeginPackage[ "Wolfram`Chatbook`" ];
 (* ::Subsection::Closed:: *)
 (*Declare Symbols*)
 `$AvailableTools;
+`$ChatAbort;
 `$ChatHandlerData;
 `$ChatPost;
 `$ChatPre;

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1749,7 +1749,7 @@ activeAIAssistantCell[
                 Editable        -> False,
                 CellDingbat     -> Cell[ BoxData @ makeActiveOutputDingbat @ settings, Background -> None ],
                 CellTrayWidgets -> <| "ChatFeedback" -> <| "Visible" -> False |> |>,
-                TaggingRules    -> <| "ChatNotebookSettings" -> settings |>
+                TaggingRules    -> <| "ChatNotebookSettings" -> smallSettings @ settings |>
             ]
         ]
     ];
@@ -1802,7 +1802,7 @@ activeAIAssistantCell[
             Selectable         -> True,
             ShowAutoSpellCheck -> False,
             ShowCursorTracker  -> False,
-            TaggingRules       -> <| "ChatNotebookSettings" -> settings |>,
+            TaggingRules       -> <| "ChatNotebookSettings" -> smallSettings @ settings |>,
             If[ scrollOutputQ @ settings,
                 PrivateCellOptions -> { "TrackScrollingWhenPlaced" -> True },
                 Sequence @@ { }
@@ -1896,8 +1896,10 @@ makeActiveOutputDingbat // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*makeOutputDingbat*)
 makeOutputDingbat // beginDefinition;
+makeOutputDingbat[ as: KeyValuePattern[ "LLMEvaluator" -> name_String ] ] := makeOutputDingbat[ as, name ];
 makeOutputDingbat[ as: KeyValuePattern[ "LLMEvaluator" -> config_Association ] ] := makeOutputDingbat[ as, config ];
 makeOutputDingbat[ as_Association ] := makeOutputDingbat[ as, as ];
+makeOutputDingbat[ as_, name_String ] := makeOutputDingbat[ as, GetCachedPersonaData @ name ];
 makeOutputDingbat[ as_, KeyValuePattern[ "PersonaIcon" -> icon_ ] ] := makeOutputDingbat[ as, icon ];
 makeOutputDingbat[ as_, KeyValuePattern[ "Icon" -> icon_ ] ] := makeOutputDingbat[ as, icon ];
 makeOutputDingbat[ as_, KeyValuePattern[ "Default" -> icon_ ] ] := makeOutputDingbat[ as, icon ];

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -71,6 +71,7 @@ $$validRootSettingValue = Inherited | _? (AssociationQ@*Association);
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Defaults*)
+$ChatAbort    = None;
 $ChatPost     = None;
 $ChatPre      = None;
 $DefaultModel = <| "Service" -> "OpenAI", "Name" -> "gpt-4" |>;
@@ -79,8 +80,9 @@ $DefaultModel = <| "Service" -> "OpenAI", "Name" -> "gpt-4" |>;
 (* ::Subsection::Closed:: *)
 (*Handler Functions*)
 $DefaultChatHandlerFunctions = <|
-    "ChatPost" :> $ChatPost,
-    "ChatPre"  :> $ChatPre
+    "ChatAbort" :> $ChatAbort,
+    "ChatPost"  :> $ChatPost,
+    "ChatPre"   :> $ChatPre
 |>;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
When a user triggers an abort (e.g. using alt-. or the evaluation menu), the asynchronous task would previously keep running, displaying new chat output. However, the code to finalize the chat output had been cancelled, so the cell remained in in an active state even when finished.

This update changes the behavior associated with user aborts that are issued during chat evaluation by immediately evaluating the "StopChat" action. Now a user abort is effectively equivalent to hitting the red "X" button to stop a chat in progress.

This also introduces a new handler function "ChatAbort", which will run during the stop chat cleanup step.

# Before
![ChatAbortBefore](https://github.com/WolframResearch/Chatbook/assets/6674723/1ee6ee3d-2174-43b9-a123-f8973a08c50c)

# After
![ChatAbortAfter](https://github.com/WolframResearch/Chatbook/assets/6674723/5232da81-130c-4a66-866a-1b49f09cd0e5)
