### PR TITLE
Bugfix: Use `Import` as a fallback for the WebFetcher tool when `StartWebSession` fails

### DIFF
--- a/Source/Chatbook/Tools/DefaultTools.wl
+++ b/Source/Chatbook/Tools/DefaultTools.wl
@@ -584,6 +584,9 @@ fetchWebText[ url_String, session_WebSessionObject ] := Enclose[
     shortenWebText @ niceWebText @ Import[ url, { "HTML", "Plaintext" } ] &
 ];
 
+fetchWebText[ url_String, _Missing | _? FailureQ ] :=
+    shortenWebText @ niceWebText @ Import[ url, { "HTML", "Plaintext" } ];
+
 fetchWebText // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -635,7 +638,13 @@ validWebSessionQ[ ___ ] := False;
 (* ::Subsubsection::Closed:: *)
 (*startWebSession*)
 startWebSession // beginDefinition;
-startWebSession[ ] := $currentWebSession = StartWebSession[ Visible -> $webSessionVisible ];
+
+startWebSession[ ] := $currentWebSession =
+    If[ TrueQ @ $CloudEvaluation,
+        Missing[ "NotAvailable" ],
+        StartWebSession[ Visible -> $webSessionVisible ]
+    ];
+
 startWebSession // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
# Before
<img width="585" alt="Screenshot 2024-01-22 144954" src="https://github.com/WolframResearch/Chatbook/assets/6674723/bd4a98ca-ff50-49ed-a4eb-4a5573bc10ef">


# After
<img width="605" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/7e54a51a-fc32-45ab-b33a-63130afe25d6">
