### PR TITLE
Improve formatting for outputs that contain `$` to denote currency

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -137,6 +137,9 @@ makeResultCell0[ codeBlockCell[ language_String, code_String ] ] :=
 
 makeResultCell0[ inlineCodeCell[ code_String ] ] := makeInlineCodeCell @ code;
 
+makeResultCell0[ mathCell[ math_String ] ] /; StringMatchQ[ math, (DigitCharacter|"."|","|" ").. ] :=
+    math;
+
 makeResultCell0[ mathCell[ math_String ] ] :=
     With[ { boxes = Quiet @ InputAssistant`TeXAssistant @ StringTrim @ math },
         If[ MatchQ[ boxes, _RawBoxes ],

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -674,7 +674,7 @@ $textDataFormatRules = {
     "``" ~~ code__ ~~ "``" /; StringFreeQ[ code, "``" ] :> inlineCodeCell @ code,
     "`" ~~ code: Except[ WhitespaceCharacter ].. ~~ "`" /; inlineSyntaxQ @ code :> inlineCodeCell @ code,
     "`" ~~ code: Except[ "`"|"\n" ].. ~~ "`" :> inlineCodeCell @ code,
-    "$$" ~~ math: Except[ "$" ].. ~~ "$$" :> mathCell @ math,
+    "$$" ~~ math__ ~~ "$$" /; StringFreeQ[ math, "$$" ] :> mathCell @ math,
     "\\(" ~~ math__ ~~ "\\)" /; StringFreeQ[ math, "\\)" ] :> mathCell @ math,
     "\\[" ~~ math__ ~~ "\\]" /; StringFreeQ[ math, "\\]" ] :> mathCell @ math,
     "$" ~~ math: Except[ "$" ].. ~~ "$" /; probablyMathQ @ math :> mathCell @ math

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -677,7 +677,7 @@ $textDataFormatRules = {
     "$$" ~~ math: Except[ "$" ].. ~~ "$$" :> mathCell @ math,
     "\\(" ~~ math__ ~~ "\\)" /; StringFreeQ[ math, "\\)" ] :> mathCell @ math,
     "\\[" ~~ math__ ~~ "\\]" /; StringFreeQ[ math, "\\]" ] :> mathCell @ math,
-    "$" ~~ math: Except[ "$" ].. ~~ "$" :> mathCell @ math
+    "$" ~~ math: Except[ "$" ].. ~~ "$" /; probablyMathQ @ math :> mathCell @ math
 };
 
 (* ::**************************************************************************************************************:: *)
@@ -1615,6 +1615,19 @@ nameQ[ ___ ] := False;
 (*inlineSyntaxQ*)
 inlineSyntaxQ[ s_String ] := ! StringStartsQ[ s, "`" ] && Internal`SymbolNameQ[ unescapeInlineMarkdown @ s<>"x", True ];
 inlineSyntaxQ[ ___ ] := False;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*probablyMathQ*)
+probablyMathQ[ s_String ] := And[
+    StringFreeQ[ s, "\n" ],
+    StringLength @ s < 100,
+    Or[ StringMatchQ[ s, (LetterCharacter|DigitCharacter|"("|")").. ],
+        StringContainsQ[ s, "+" | "-" | "=" | "^" | ("\\" ~~ WordCharacter..) ]
+    ]
+];
+
+probablyMathQ[ ___ ] := False;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -711,15 +711,32 @@ $dynamicSplitRules = {
 
 (* cSpell: ignore textit, textbf *)
 $stringFormatRules = {
-    "***" ~~ text: Except[ "*" ].. ~~ "***" :> styleBox[ text, FontWeight -> Bold, FontSlant -> Italic ],
-    "___" ~~ text: Except[ "_" ].. ~~ "___" :> styleBox[ text, FontWeight -> Bold, FontSlant -> Italic ],
-    "**" ~~ text: Except[ "*" ].. ~~ "**" :> styleBox[ text, FontWeight -> Bold ],
-    "__" ~~ text: Except[ "_" ].. ~~ "__" :> styleBox[ text, FontWeight -> Bold ],
-    "*" ~~ text: Except[ "*" ].. ~~ "*" :> styleBox[ text, FontSlant -> Italic ],
-    "_" ~~ text: Except[ "_" ].. ~~ "_" :> styleBox[ text, FontSlant -> Italic ],
-    "[" ~~ label: Except[ "[" ].. ~~ "](" ~~ url: Except[ ")" ].. ~~ ")" :> hyperlink[ label, url ],
-    "\\textit{" ~~ text__ ~~ "}" /; StringFreeQ[ text, "{"|"}" ] :> styleBox[ text, FontSlant -> Italic ],
-    "\\textbf{" ~~ text__ ~~ "}" /; StringFreeQ[ text, "{"|"}" ] :> styleBox[ text, FontWeight -> Bold ]
+    "***" ~~ text: Except[ "*" ].. ~~ "***" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontWeight -> Bold, FontSlant -> Italic ],
+
+    "___" ~~ text: Except[ "_" ].. ~~ "___" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontWeight -> Bold, FontSlant -> Italic ],
+
+    "**" ~~ text: Except[ "*" ].. ~~ "**" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontWeight -> Bold ],
+
+    "__" ~~ text: Except[ "_" ].. ~~ "__" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontWeight -> Bold ],
+
+    "*" ~~ text: Except[ "*" ].. ~~ "*" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontSlant -> Italic ],
+
+    "_" ~~ text: Except[ "_" ].. ~~ "_" /; StringFreeQ[ text, "\n" ] :>
+        styleBox[ text, FontSlant -> Italic ],
+
+    "[" ~~ label: Except[ "[" ].. ~~ "](" ~~ url: Except[ ")" ].. ~~ ")" :>
+        hyperlink[ label, url ],
+
+    "\\textit{" ~~ text__ ~~ "}" /; StringFreeQ[ text, "{"|"}" ] :>
+        styleBox[ text, FontSlant -> Italic ],
+
+    "\\textbf{" ~~ text__ ~~ "}" /; StringFreeQ[ text, "{"|"}" ] :>
+        styleBox[ text, FontWeight -> Bold ]
 };
 
 (* ::**************************************************************************************************************:: *)

--- a/Source/Chatbook/Prompting.wl
+++ b/Source/Chatbook/Prompting.wl
@@ -128,6 +128,7 @@ $basePromptComponents[ "MathExpressions" ] = "\
 * Write math expressions using LaTeX and surround them with dollar signs: $$x^2 + y^2$$";
 
 $basePromptComponents[ "EscapedCharacters" ] = "\
+* If your response contains currency in dollars, write with an escaped dollar sign: \\$99.95.
 * IMPORTANT! Whenever you write a literal backtick (`) or dollar sign ($) in text, ALWAYS escape it with a backslash. \
 Example: It costs me \\$99.95 every time you forget to escape \\` or \\$ properly!";
 

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -892,7 +892,10 @@ serializeTraditionalForm[ box: FormBox[ inner_, ___ ] ] := serializeTraditionalF
     Module[ { string },
         string = Quiet @ ExportString[ Cell @ BoxData @ box, "TeXFragment" ];
         If[ StringQ @ string && StringMatchQ[ string, "\\("~~__~~"\\)"~~WhitespaceCharacter... ],
-            StringReplace[ StringTrim @ string, StartOfString~~"\\("~~math__~~"\\)"~~EndOfString :> "$$"<>math<>"$$" ],
+            fixLineEndings @ StringReplace[
+                StringTrim @ string,
+                StartOfString~~"\\("~~math__~~"\\)"~~EndOfString :> "$$"<>math<>"$$"
+            ],
             fasterCellToString0 @ inner
         ]
     ];

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -840,7 +840,7 @@ fasterCellToString0[
 (* TeXAssistantTemplate *)
 fasterCellToString0[ TemplateBox[ KeyValuePattern[ "input" -> string_ ], "TeXAssistantTemplate" ] ] := (
     needsBasePrompt[ "Math" ];
-    "$" <> string <> "$"
+    "$$" <> string <> "$$"
 );
 
 (* Inline WL code template *)

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -868,6 +868,21 @@ fasterCellToString0[ TemplateBox[ args_, ___, InterpretationFunction -> f_, ___ 
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsubsection::Closed:: *)
+(*TeX*)
+fasterCellToString0[ FormBox[
+    StyleBox[ RowBox @ { "L", StyleBox[ AdjustmentBox[ "A", ___ ], ___ ], "T", AdjustmentBox[ "E", ___ ], "X" }, ___ ],
+    TraditionalForm,
+    ___
+] ] := "LaTeX";
+
+fasterCellToString0[ FormBox[
+    StyleBox[ RowBox @ { "T", AdjustmentBox[ "E", ___ ], "X" }, ___ ],
+    TraditionalForm,
+    ___
+] ] := "TeX";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
 (*Math Boxes*)
 
 (* Sqrt *)

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -150,7 +150,6 @@ $$graphicsBox = $graphicsHeads[ ___ ] | TemplateBox[ _, "Legended", ___ ];
 $stringStripHeads = Alternatives[
     ButtonBox,
     CellGroupData,
-    FormBox,
     FrameBox,
     ItemBox,
     PaneBox,
@@ -881,6 +880,25 @@ fasterCellToString0[ FormBox[
     ___
 ] ] := "TeX";
 
+fasterCellToString0[ box: FormBox[ _, TraditionalForm, ___ ] ] :=
+    serializeTraditionalForm @ box;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsubsection::Closed:: *)
+(*serializeTraditionalForm*)
+serializeTraditionalForm // beginDefinition;
+
+serializeTraditionalForm[ box: FormBox[ inner_, ___ ] ] := serializeTraditionalForm[ box ] =
+    Module[ { string },
+        string = Quiet @ ExportString[ Cell @ BoxData @ box, "TeXFragment" ];
+        If[ StringQ @ string && StringMatchQ[ string, "\\("~~__~~"\\)"~~WhitespaceCharacter... ],
+            StringReplace[ StringTrim @ string, StartOfString~~"\\("~~math__~~"\\)"~~EndOfString :> "$$"<>math<>"$$" ],
+            fasterCellToString0 @ inner
+        ]
+    ];
+
+serializeTraditionalForm // endDefinition;
+
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsubsection::Closed:: *)
 (*Math Boxes*)
@@ -1164,6 +1182,7 @@ fasterCellToString0[ DynamicModuleBox[ a___ ] ] /; ! TrueQ @ $CellToStringDebug 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsubsection::Closed:: *)
 (*Ignored/Skipped*)
+fasterCellToString0[ FormBox[ box_, ___ ] ] := fasterCellToString0 @ box;
 fasterCellToString0[ $ignoredBoxPatterns ] := "";
 fasterCellToString0[ $stringStripHeads[ a_, ___ ] ] := fasterCellToString0 @ a;
 


### PR DESCRIPTION
# Before

<img width="591" alt="Screenshot 2024-01-23 111852" src="https://github.com/WolframResearch/Chatbook/assets/6674723/78ac556a-1bd3-435b-b246-0122667043e8">

# After

<img width="589" alt="Screenshot 2024-01-23 111200" src="https://github.com/WolframResearch/Chatbook/assets/6674723/98e54e5d-74d4-4f94-9622-1ca0a743b2d9">
