### PR TITLE
Support `AppearanceRules` for tools

### DIFF
--- a/Source/Chatbook/ToolManager.wl
+++ b/Source/Chatbook/ToolManager.wl
@@ -431,7 +431,7 @@ addPersonaSource[ tools_List, name_String ] :=
     addPersonaSource[ #, name ] & /@ tools;
 
 addPersonaSource[ HoldPattern @ LLMTool[ as_Association, a___ ], name_String ] :=
-    LLMTool[ Association[ "Source" -> "Persona", "PersonaName" -> name, as ], a ];
+    LLMTool[ Association[ "Origin" -> "Persona", "PersonaName" -> name, as ], a ];
 
 addPersonaSource[ tool_, _ ] :=
     tool;
@@ -626,8 +626,8 @@ configurableToolQ // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*deletableToolQ*)
 deletableToolQ // beginDefinition;
-deletableToolQ[ KeyValuePattern[ "Source" -> "BuiltIn" ] ] := False;
-deletableToolQ[ KeyValuePattern[ "Source" -> "Persona" ] ] := False;
+deletableToolQ[ KeyValuePattern[ "Origin" -> "BuiltIn" ] ] := False;
+deletableToolQ[ KeyValuePattern[ "Origin" -> "Persona" ] ] := False;
 deletableToolQ[ tool_ ] := True;
 deletableToolQ // endDefinition;
 
@@ -821,12 +821,12 @@ deleteButton0 // endDefinition;
 (*nonDeletableTooltip*)
 nonDeletableTooltip // beginDefinition;
 
-nonDeletableTooltip[ KeyValuePattern @ { "CanonicalName" -> name_String, "Source" -> "BuiltIn" } ] :=
+nonDeletableTooltip[ KeyValuePattern @ { "CanonicalName" -> name_String, "Origin" -> "BuiltIn" } ] :=
     name<>" is a built-in tool and cannot be deleted.";
 
 nonDeletableTooltip[ KeyValuePattern @ {
     "CanonicalName" -> name_String,
-    "Source"        -> "Persona",
+    "Origin"        -> "Persona",
     "PersonaName"   -> persona_String
 } ] := name<>" is provided by the persona "<>persona<>" and cannot be deleted separately.";
 

--- a/Source/Chatbook/Tools/DefaultTools.wl
+++ b/Source/Chatbook/Tools/DefaultTools.wl
@@ -1153,7 +1153,7 @@ wolframLanguageData // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*getToolIcon*)
 getToolIcon // beginDefinition;
-getToolIcon[ HoldPattern @ LLMTool[ as_, ___ ] ] := getToolIcon @ toolData @ as;
+getToolIcon[ tool: $$llmTool ] := getToolIcon @ toolData @ tool;
 getToolIcon[ as_Association ] := Lookup[ toolData @ as, "Icon", RawBoxes @ TemplateBox[ { }, "WrenchIcon" ] ];
 getToolIcon[ _ ] := $defaultToolIcon;
 getToolIcon // endDefinition;
@@ -1166,8 +1166,8 @@ getToolDisplayName // beginDefinition;
 getToolDisplayName[ tool_ ] :=
     getToolDisplayName[ tool, Missing[ "NotFound" ] ];
 
-getToolDisplayName[ HoldPattern @ LLMTool[ as_, ___ ], default_ ] :=
-    getToolDisplayName @ as;
+getToolDisplayName[ tool: $$llmTool, default_ ] :=
+    getToolDisplayName @ toolData @ tool;
 
 getToolDisplayName[ as_Association, default_ ] :=
     toDisplayToolName @ Lookup[ as, "DisplayName", Lookup[ as, "Name", default ] ];

--- a/Source/Chatbook/Tools/DefaultTools.wl
+++ b/Source/Chatbook/Tools/DefaultTools.wl
@@ -32,7 +32,7 @@ Needs[ "Wolfram`Chatbook`Utils`"             ];
     "Description"        -> $chatPreferencesDescription,
     "Function"           -> chatPreferences,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "action" -> <|
             "Interpreter" -> { "get", "set" },
@@ -70,7 +70,7 @@ $defaultChatTools0[ "DocumentationSearcher" ] = <|
     "Description"        -> $documentationSearchDescription,
     "Function"           -> documentationSearch,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "query" -> <|
             "Interpreter" -> "String",
@@ -101,7 +101,7 @@ $defaultChatTools0[ "DocumentationLookup" ] = <|
     "Description"        -> "Get documentation pages for Wolfram Language symbols.",
     "Function"           -> documentationLookup,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "names" -> <|
             "Interpreter" -> DelimitedSequence[ "WolframLanguageSymbol", "," ],
@@ -224,7 +224,7 @@ $defaultChatTools0[ "WolframLanguageEvaluator" ] = <|
     "Description"        -> $sandboxEvaluateDescription,
     "Function"           -> sandboxEvaluate,
     "FormattingFunction" -> sandboxFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "code" -> <|
             "Interpreter" -> "String",
@@ -276,7 +276,7 @@ $defaultChatTools0[ "WolframAlpha" ] = <|
     "Description"        -> $wolframAlphaDescription,
     "Function"           -> getWolframAlphaText,
     "FormattingFunction" -> wolframAlphaResultFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "input" -> <|
             "Interpreter" -> "String",
@@ -444,7 +444,7 @@ $defaultChatTools0[ "WebSearcher" ] = <|
     "Description"        -> "Search the web.",
     "Function"           -> webSearch,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "query" -> <|
             "Interpreter" -> "String",
@@ -538,7 +538,7 @@ $defaultChatTools0[ "WebFetcher" ] = <|
     "Description"        -> "Fetch plain text or image links from a URL.",
     "Function"           -> webFetch,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"  -> {
         "url" -> <|
             "Interpreter" -> "URL",
@@ -659,7 +659,7 @@ $defaultChatTools0[ "WebImageSearcher" ] = <|
     "Description"        -> "Search the web for images.",
     "Function"           -> webImageSearch,
     "FormattingFunction" -> toolAutoFormatter,
-    "Source"             -> "BuiltIn",
+    "Origin"             -> "BuiltIn",
     "Parameters"         -> {
         "query" -> <|
             "Interpreter" -> "String",


### PR DESCRIPTION
This adds support for some upcoming changes to `LLMTool` which allow specifying an `AppearanceRules` option:

<img width="837" alt="Screenshot 2024-01-25 125701" src="https://github.com/WolframResearch/Chatbook/assets/6674723/8e6261fa-71d9-4085-937e-5e56aee107b4">
