### PR TITLE
Feature: Added `$ChatNotebookEvaluation` and fixed some other minor misc issues

### DIFF
--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -665,15 +665,25 @@ CopyChatObject // beginDefinition;
 
 CopyChatObject[ cell0_ ] := Enclose[
     Module[ { cell, encodedString, chatData, messages, chatObject },
+
         Quiet[ PacletInstall[ "Wolfram/LLMFunctions" ]; Needs[ "Wolfram`LLMFunctions`" -> None ] ];
         cell          = ConfirmMatch[ ensureChatOutputCell @ cell0, _CellObject, "CellObject" ];
-        encodedString = ConfirmBy[ CurrentValue[ cell, { TaggingRules, "ChatData" } ], StringQ, "EncodedString" ];
+
+        encodedString = ConfirmMatch[
+            CurrentValue[ cell, { TaggingRules, "ChatData" } ],
+            _String|Inherited,
+            "EncodedString"
+        ];
+
+        If[ encodedString === Inherited, throwMessageDialog[ "ChatObjectNotAvailable" ] ];
+
         chatData      = ConfirmBy[ BinaryDeserialize @ BaseDecode @ encodedString, AssociationQ, "ChatData" ];
         messages      = ConfirmMatch[ chatData[ "Data", "Messages" ], { __Association? AssociationQ }, "Messages" ];
         chatObject    = Confirm[ constructChatObject @ messages, "ChatObject" ];
+
         CopyToClipboard @ chatObject
     ],
-    throwInternalFailure[ HoldForm @ CopyChatObject @ cell0, ## ] &
+    throwInternalFailure
 ];
 
 CopyChatObject // endDefinition;

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -30,6 +30,7 @@ BeginPackage[ "Wolfram`Chatbook`Actions`" ];
 `autoAssistQ;
 `chatInputCellQ;
 `clearMinimizedChats;
+`revertMultimodalContent;
 `standardizeMessageKeys;
 `systemCredential;
 `toAPIKey;
@@ -667,7 +668,7 @@ CopyChatObject[ cell0_ ] := Enclose[
     Module[ { cell, encodedString, chatData, messages, chatObject },
 
         Quiet[ PacletInstall[ "Wolfram/LLMFunctions" ]; Needs[ "Wolfram`LLMFunctions`" -> None ] ];
-        cell          = ConfirmMatch[ ensureChatOutputCell @ cell0, _CellObject, "CellObject" ];
+        cell = ConfirmMatch[ ensureChatOutputCell @ cell0, _CellObject, "CellObject" ];
 
         encodedString = ConfirmMatch[
             CurrentValue[ cell, { TaggingRules, "ChatData" } ],
@@ -677,9 +678,9 @@ CopyChatObject[ cell0_ ] := Enclose[
 
         If[ encodedString === Inherited, throwMessageDialog[ "ChatObjectNotAvailable" ] ];
 
-        chatData      = ConfirmBy[ BinaryDeserialize @ BaseDecode @ encodedString, AssociationQ, "ChatData" ];
-        messages      = ConfirmMatch[ chatData[ "Data", "Messages" ], { __Association? AssociationQ }, "Messages" ];
-        chatObject    = Confirm[ constructChatObject @ messages, "ChatObject" ];
+        chatData   = ConfirmBy[ BinaryDeserialize @ BaseDecode @ encodedString, AssociationQ, "ChatData" ];
+        messages   = ConfirmMatch[ chatData[ "Data", "Messages" ], { __Association? AssociationQ }, "Messages" ];
+        chatObject = Confirm[ constructChatObject @ messages, "ChatObject" ];
 
         CopyToClipboard @ chatObject
     ],

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -165,6 +165,11 @@ KeyValueMap[ Function[ MessageName[ Chatbook, #1 ] = #2 ], <|
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
+(*$ChatNotebookEvaluation*)
+$ChatNotebookEvaluation = False;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
 (*Initialization*)
 $debug           = True;
 $failed          = False;
@@ -375,11 +380,12 @@ catchTop[ eval_ ] := catchTop[ eval, Chatbook ];
 catchTop[ eval_, sym_Symbol ] :=
     Block[
         {
-            $messageSymbol = Replace[ $messageSymbol, Chatbook -> sym ],
-            $catching      = True,
-            $failed        = False,
-            catchTop       = # &,
-            catchTopAs     = (#1 &) &
+            $ChatNotebookEvaluation = True,
+            $messageSymbol          = Replace[ $messageSymbol, Chatbook -> sym ],
+            $catching               = True,
+            $failed                 = False,
+            catchTop                = # &,
+            catchTopAs              = (#1 &) &
         },
         Catch[ eval, $catchTopTag ]
     ];

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -126,6 +126,7 @@ KeyValueMap[ Function[ MessageName[ Chatbook, #1 ] = #2 ], <|
     "APIKeyOrganizationID"            -> "The value specified for the API key appears to be an organization ID instead of an API key. Visit `1` to manage your API keys.",
     "BadResponseMessage"              -> "`1`",
     "ChannelFrameworkError"           -> "The channel framework is currently unavailable, please try installing from URL instead or try again later.",
+    "ChatObjectNotAvailable"          -> "The chat object for this cell is no longer available.",
     "ConnectionFailure"               -> "Server connection failure: `1`. Please try again later.",
     "ConnectionFailure2"              -> "Could not get a valid response from the server: `1`. Please try again later.",
     "ExpectedInstallableResourceType" -> "Expected a resource of type `1` instead of `2`.",

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -1402,6 +1402,9 @@ attachment[ alt_String, key_String ] := attachment[ alt, key, $attachments[ key 
 attachment[ alt_String, key_String, HoldComplete[ expr_ ] ] := attachment[ alt, key, Defer @ expr ];
 attachment[ alt_String, key_String, _Missing ] := attachment[ alt, key, $missingImage ];
 
+attachment[ alt_String, key_String, Defer[ img_Image ] ] /; ImageQ @ Unevaluated @ img :=
+    Cell[ BoxData @ PaneBox[ attachmentBoxes[ alt, key, resizeImage @ img ], ImageMargins -> 10 ], Background -> None ];
+
 attachment[ alt_String, key_String, expr_ ] /; $dynamicText :=
     codeBlockFrame[ Cell[ BoxData @ attachmentBoxes[ alt, key, expr ], "ChatCodeActive" ], expr ];
 

--- a/Source/Chatbook/Main.wl
+++ b/Source/Chatbook/Main.wl
@@ -10,6 +10,7 @@ BeginPackage[ "Wolfram`Chatbook`" ];
 `$ChatAbort;
 `$ChatbookContexts;
 `$ChatHandlerData;
+`$ChatNotebookEvaluation;
 `$ChatPost;
 `$ChatPre;
 `$DefaultChatHandlerFunctions;
@@ -107,6 +108,7 @@ Block[ { $ContextPath },
 (* ::Section::Closed:: *)
 (*Protected Symbols*)
 Protect[
+    $ChatNotebookEvaluation,
     $DefaultChatHandlerFunctions,
     $DefaultChatProcessingFunctions,
     $DefaultModel,

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -2251,7 +2251,10 @@ makeCompactChatData[
                 "MessageTag" -> tag,
                 "Data" -> Association[
                     data,
-                    "Messages" -> Append[ messages, <| "Role" -> "Assistant", "Content" -> message |> ]
+                    "Messages" -> revertMultimodalContent @ Append[
+                        messages,
+                        <| "Role" -> "Assistant", "Content" -> message |>
+                    ]
                 ]
             ],
             Inherited

--- a/Source/Chatbook/Tools/Common.wl
+++ b/Source/Chatbook/Tools/Common.wl
@@ -650,10 +650,7 @@ makeToolPrompt[ settings_Association ] := $lastToolPrompt = TemplateObject[
                         "Tool Name: ",
                         TemplateSlot[ "Name" ],
                         "\nDisplay Name: ",
-                        TemplateSlot[
-                            "DisplayName",
-                            DefaultValue :> TemplateExpression @ toDisplayToolName @ TemplateSlot[ "Name" ]
-                        ],
+                        TemplateSlot[ "DisplayName" ],
                         "\nDescription: ",
                         TemplateSlot[ "Description" ],
                         "\nSchema:\n",
@@ -664,7 +661,11 @@ makeToolPrompt[ settings_Association ] := $lastToolPrompt = TemplateObject[
                     InsertionFunction -> TextString
                 ],
                 TemplateExpression @ Map[
-                    Append[ #[ "Data" ], "Schema" -> ExportString[ #[ "JSONSchema" ], "JSON" ] ] &,
+                    Association[
+                        #[ "Data" ],
+                        "Schema" -> ExportString[ #[ "JSONSchema" ], "JSON" ],
+                        "DisplayName" -> getToolDisplayName @ #
+                    ] &,
                     TemplateSlot[ "Tools" ]
                 ]
             ],

--- a/Source/Chatbook/Tools/DefaultTools.wl
+++ b/Source/Chatbook/Tools/DefaultTools.wl
@@ -1170,7 +1170,7 @@ getToolDisplayName[ tool: $$llmTool, default_ ] :=
     getToolDisplayName @ toolData @ tool;
 
 getToolDisplayName[ as_Association, default_ ] :=
-    toDisplayToolName @ Lookup[ as, "DisplayName", Lookup[ as, "Name", default ] ];
+    Lookup[ as, "DisplayName", toDisplayToolName @ Lookup[ as, "Name", default ] ];
 
 getToolDisplayName[ _, default_ ] :=
     default;


### PR DESCRIPTION
Added `$ChatNotebookEvaluation`, which gives `True` when in a chat notebook evaluation and `False` otherwise. This lets you define alternate tool behavior for `LLMTool`, personas, etc depending on whether or not evaluation is happening in a chat notebook or programmatically.

For example, define an LLMTool that does something different in a chat notebook environment:
```
LLMTool["...", {...}, If[Wolfram`Chatbook`$ChatNotebookEvaluation, f[#], g[#]] &]
```