### PR TITLE
Bugfix: Handle service API errors better when retrieving model lists for the preferences dialog

### DIFF
--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -1,7 +1,7 @@
 PacletObject[ <|
     "Name"           -> "Wolfram/Chatbook",
     "PublisherID"    -> "Wolfram",
-    "Version"        -> "1.4.3",
+    "Version"        -> "1.4.4",
     "WolframVersion" -> "13.3+",
     "Description"    -> "Wolfram Notebooks + LLMs",
     "License"        -> "MIT",

--- a/Source/Chatbook/PreferencesContent.wl
+++ b/Source/Chatbook/PreferencesContent.wl
@@ -563,6 +563,13 @@ makeModelNameSelector[
             "ServiceModelList"
         ];
 
+        (* TODO:
+               If the underlying ServiceExecute in getServiceModelList fails (e.g. due to API issues), it currently
+               returns Missing["NoModelList"]. It might be better to have it return an appropriate Failure[...] instead.
+               In this case, we would want to indicate to the user that the service is not available, rather than
+               falling back to the input field method.
+        *)
+
         If[ models === Missing[ "NotConnected" ],
             Throw @ serviceConnectButton[
                 Dynamic @ service,

--- a/Source/Chatbook/Services.wl
+++ b/Source/Chatbook/Services.wl
@@ -124,6 +124,9 @@ getServiceModelList[ service_String, info_, models0_List ] := Enclose[
     throwInternalFailure
 ];
 
+getServiceModelList[ service_String, info_, Missing[ "NoModelList" ] ] :=
+    Missing[ "NoModelList" ];
+
 getServiceModelList // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
If the API call to get the model list fails, the model selector in the preferences dialog will now fall back to the input field method instead of generating an internal error.

<img width="866" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/1cfc87a8-d1fe-4dc2-bfbe-f1ce27ac9d43">
