### PR TITLE
Bugfix: Fixed pink boxing that occurs in cloud when chat outputs contain inline section cells

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -163,7 +163,7 @@ makeResultCell0[ bulletCell[ whitespace_String, item_String ] ] := Flatten @ {
 
 makeResultCell0[ sectionCell[ n_, section_String ] ] := Flatten @ {
     "\n",
-    StyleBox[ formatTextString @ section, sectionStyle @ n, "InlineSection", FontSize -> .8*Inherited ],
+    styleBox[ formatTextString @ section, sectionStyle @ n, "InlineSection", FontSize -> .8*Inherited ],
     $tinyLineBreak
 };
 


### PR DESCRIPTION
# Before
<img width="600" alt="Screenshot 2024-02-16 115335" src="https://github.com/WolframResearch/Chatbook/assets/6674723/c2ed1a18-d738-491d-a9b0-a94e697a21aa">

# After
<img width="598" alt="image" src="https://github.com/WolframResearch/Chatbook/assets/6674723/14e22dc4-69a9-47ad-a42c-1d36c1eece91">
