### PR TITLE
Bugfix: Make cloud tagging rules inheritence fix version independent

### DIFF
--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -21,7 +21,7 @@ Needs[ "Wolfram`Chatbook`ResourceInstaller`" ];
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Configuration*)
-$cloudInheritanceFix := $cloudNotebooks && ! PacletNewerQ[ $CloudVersionNumber, "1.67.1" ];
+$cloudInheritanceFix := $cloudNotebooks;
 
 (* cSpell: ignore AIAPI *)
 $defaultChatSettings = <|


### PR DESCRIPTION
(cherry picked from commit b7e3a3d10c0c9c4d0cfe0feac0f0081b1e1d09dc)

I'm not sure why I had this version check in the first place.