### PR TITLE
621 an uncaught throw in the evaluator tool gives an internal error

### DIFF
--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -673,8 +673,8 @@ initializeExpressions[ flat: HoldComplete @ Association @ OrderlessPatternSequen
         ReplacePart[ flat, Thread[ pos -> Extract[ flat, pos ] ] ]
     ];
 
-initializeExpressions[ HoldComplete @ Hold[ failure_ ] ] :=
-    With[ { as = <| "Line" -> $currentLineNumber-1, "Result" -> Hold @ failure, "Initialized" -> { } |> },
+initializeExpressions[ HoldComplete[ failure_ ] ] :=
+    With[ { as = <| "Line" -> $currentLineNumber-1, "Result" -> HoldComplete @ failure, "Initialized" -> { } |> },
         HoldComplete @ as
     ];
 

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -972,6 +972,9 @@ writeResult // endDefinition;
 (*extractBodyData*)
 extractBodyData // beginDefinition;
 
+extractBodyData[ { ___, KeyValuePattern[ "TaskStatus" -> "Finished" ], rest__ } ] :=
+    extractBodyData @ { rest };
+
 extractBodyData[ log_List ] := Enclose[
     Catch @ Module[ { chunks, folded, data, xml },
 


### PR DESCRIPTION
# Before

<img width="664" alt="Screenshot 2024-03-15 084040" src="https://github.com/WolframResearch/Chatbook/assets/6674723/a19480be-5983-491c-8ed4-2324c35feb10">

# After

<img width="659" alt="Screenshot 2024-03-15 092432" src="https://github.com/WolframResearch/Chatbook/assets/6674723/ef30bd46-01ee-4ebc-8653-09ecc2276157">

This also now handles other exceptions, like `TerminatedEvaluation[...]` and kernel quits:

<img width="662" alt="Screenshot 2024-03-15 102615" src="https://github.com/WolframResearch/Chatbook/assets/6674723/61ee069c-2bf2-41cd-8acd-4af9b73e282a">
