### PR TITLE
Bugfix: Fixed internal error that occurs if the AI writes an unbalanced markdown table

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -383,9 +383,33 @@ textTableForm[ items_? MatrixQ, opts___ ] := Pane[
     ImageMargins -> { { 0, 0 }, { 5, 5 } }
 ];
 
+(* Not a rectangular set of table items, so we'll pad as necessary: *)
+textTableForm[ items: { __List }, opts___ ] := Enclose[
+    Module[ { width, padded, trimmed },
+        (* Get the maximum row length: *)
+        width = ConfirmBy[ Max[ Length /@ items ], Positive, "Width" ];
+
+        (* Pad all rows to match: *)
+        padded = ConfirmBy[ PadRight[ #, width, "" ] & /@ items, MatrixQ, "Padded" ];
+
+        (* Remove the right-most column if it just contains empty strings: *)
+        trimmed = ConfirmBy[
+            FixedPoint[ Replace[ i: { { __, "" }.. } :> i[[ All, 1;;-2 ]] ], padded ],
+            MatrixQ,
+            "Trimmed"
+        ];
+
+        (* Items are now rectangular, so proceed with previous definition: *)
+        textTableForm[ trimmed, opts ]
+    ],
+    throwInternalFailure
+];
+
 textTableForm // endDefinition;
 
-
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*formatRaw*)
 formatRaw // beginDefinition;
 formatRaw[ "" ] := "";
 formatRaw[ item_String ] := formatRaw[ item, styleBox @ item ];


### PR DESCRIPTION
# Before

<img width="545" alt="Screenshot 2024-03-15 105516" src="https://github.com/WolframResearch/Chatbook/assets/6674723/5a273efc-2993-4213-8a07-81653b4aa4af">


# After

<img width="547" alt="Screenshot 2024-03-15 105545" src="https://github.com/WolframResearch/Chatbook/assets/6674723/c47e109f-a79f-4bf2-8edd-0cee9c9efb47">

