### PR TITLE
Automatically remove the string `"<|image_sentinel|>"` from chat outputs

### DIFF
--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -831,6 +831,8 @@ $llmAutoCorrectRules = Flatten @ {
     "<" ~~ Shortest[ scheme: LetterCharacter.. ~~ "://" ~~ id: Except[ "!" ].. ] ~~ ">" :>
         "<!" <> scheme <> "://" <> id <> "!>",
     "\\uf351" -> "\[FreeformPrompt]",
+    "\n<|image_sentinel|>\n" :> "\n",
+    "<|image_sentinel|>" :> "",
     $longNameCharacters
 };
 


### PR DESCRIPTION
This occasionally appears in chat outputs when using gpt-4-vision. It's clearly a special token used by OpenAI, since the vision model can't read it like other models can:
```
In[1]:= AssociationMap[
    Function[
        LLMSynthesize[
            "Repeat the following string back to me:\nMy favorite token is <|image_sentinel|>!",
            LLMEvaluator -> <| "Model" -> #1, "MaxTokens" -> 64 |>
        ]
    ],
    { "gpt-3.5-turbo", "gpt-4", "gpt-4-turbo-preview", "gpt-4-vision-preview" }
]

Out[1]= <|
    "gpt-3.5-turbo"        -> "My favorite token is <|image_sentinel|>!",
    "gpt-4"                -> "My favorite token is <|image_sentinel|>!",
    "gpt-4-turbo-preview"  -> "My favorite token is <|image_sentinel|>!",
    "gpt-4-vision-preview" -> "\"My favorite token is !\""
|>
```

The fact that it occasionally appears in chat outputs is almost certainly a bug on OpenAI's end. However, it's simple enough to just delete it from chat outputs as a workaround.