### PR TITLE
Add support for Claude 3

### DIFF
--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -73,7 +73,7 @@ $styleRoles = <|
     "ChatSystemInput"        -> "System"
 |>;
 
-$cachedTokenizerNames = { "chat-bison", "claude", "gpt-2", "gpt-3.5", "gpt-4-vision", "gpt-4" };
+$cachedTokenizerNames = { "chat-bison", "claude", "claude-3", "gpt-2", "gpt-3.5", "gpt-4-vision", "gpt-4" };
 $cachedTokenizers     = <| |>;
 $fallbackTokenizer    = "gpt-2";
 
@@ -1299,7 +1299,7 @@ findTokenizer // endDefinition;
 (*Pre-cached small tokenizer functions*)
 $cachedTokenizers[ "chat-bison"   ] = ToCharacterCode[ #, "UTF8" ] &;
 $cachedTokenizers[ "gpt-4-vision" ] = If[ graphicsQ @ #, gpt4ImageTokenizer, cachedTokenizer[ "gpt-4" ] ][ # ] &;
-$cachedTokenizers[ "claude3"      ] = If[ graphicsQ @ #, claude3ImageTokenizer, cachedTokenizer[ "claude" ] ][ # ] &;
+$cachedTokenizers[ "claude-3"     ] = If[ graphicsQ @ #, claude3ImageTokenizer, cachedTokenizer[ "claude" ] ][ # ] &;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -363,6 +363,14 @@ combineExcisedMessages // endDefinition;
 (*tokenCheckedMessage*)
 tokenCheckedMessage // beginDefinition;
 
+tokenCheckedMessage[
+    as: KeyValuePattern[ "TokenizerName" -> "claude-3" ],
+    message0: KeyValuePattern @ { "Role" -> "Assistant", "Content" -> Except[ _String ] }
+] :=
+    With[ { message = revertMultimodalContent @ message0 },
+        tokenCheckedMessage[ as, message ] /; MatchQ[ message, KeyValuePattern[ "Content" -> _String ] ]
+    ];
+
 tokenCheckedMessage[ as_Association, message_ ] /; $cellStringBudget === Infinity := message;
 
 tokenCheckedMessage[ as_Association, message_ ] := Enclose[

--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -1298,7 +1298,8 @@ findTokenizer // endDefinition;
 (* ::Subsubsubsection::Closed:: *)
 (*Pre-cached small tokenizer functions*)
 $cachedTokenizers[ "chat-bison"   ] = ToCharacterCode[ #, "UTF8" ] &;
-$cachedTokenizers[ "gpt-4-vision" ] = If[ graphicsQ[ # ], gpt4ImageTokenizer[ # ], cachedTokenizer[ "gpt-4" ][ # ] ] &;
+$cachedTokenizers[ "gpt-4-vision" ] = If[ graphicsQ @ #, gpt4ImageTokenizer, cachedTokenizer[ "gpt-4" ] ][ # ] &;
+$cachedTokenizers[ "claude3"      ] = If[ graphicsQ @ #, claude3ImageTokenizer, cachedTokenizer[ "claude" ] ][ # ] &;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -1347,6 +1348,14 @@ gpt4ImageTokenizer // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*claude3ImageTokenizer*)
+claude3ImageTokenizer // beginDefinition;
+claude3ImageTokenizer[ image_ ] := claude3ImageTokenizer[ image, claude3ImageTokenCount @ image ];
+claude3ImageTokenizer[ image_, count: $$size ] := ConstantArray[ 0, count ]; (* TODO: just a placeholder for counting *)
+claude3ImageTokenizer // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*gpt4ImageTokenCount*)
 gpt4ImageTokenCount // beginDefinition;
 gpt4ImageTokenCount[ image_ ] := gpt4ImageTokenCount[ image, gpt4ImageTokenCount0 @ image ];
@@ -1360,6 +1369,22 @@ gpt4ImageTokenCount0[ image_, resized_Image ] := gpt4ImageTokenCount0[ image, Im
 gpt4ImageTokenCount0[ image_, { w_, h_ } ] := gpt4ImageTokenCount0[ w, h ];
 gpt4ImageTokenCount0[ w_Integer, h_Integer ] := 85 + 170 * Ceiling[ h / 512 ] * Ceiling[ w / 512 ];
 gpt4ImageTokenCount0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*claude3ImageTokenCount*)
+claude3ImageTokenCount // beginDefinition;
+claude3ImageTokenCount[ image_ ] := claude3ImageTokenCount[ image, claude3ImageTokenCount0 @ image ];
+claude3ImageTokenCount[ image_, count: $$size ] := claude3ImageTokenCount[ image ] = count;
+claude3ImageTokenCount // endDefinition;
+
+
+claude3ImageTokenCount0 // beginDefinition;
+claude3ImageTokenCount0[ image_ ] := claude3ImageTokenCount0[ image, resizeMultimodalImage @ image ];
+claude3ImageTokenCount0[ image_, resized_Image ] := claude3ImageTokenCount0[ image, ImageDimensions @ resized ];
+claude3ImageTokenCount0[ image_, { w_, h_ } ] := claude3ImageTokenCount0[ w, h ];
+claude3ImageTokenCount0[ w_Integer, h_Integer ] := Ceiling[ (w * h) / 750 ];
+claude3ImageTokenCount0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)

--- a/Source/Chatbook/Models.wl
+++ b/Source/Chatbook/Models.wl
@@ -205,8 +205,27 @@ fineTunedModelQ // endDefinition;
 (*multimodalModelQ*)
 (* FIXME: this should be a queryable property from LLMServices: *)
 multimodalModelQ // beginDefinition;
-multimodalModelQ[ name_String? StringQ ] := StringContainsQ[ toModelName @ name, "gpt-"~~$$modelVersion~~"-vision" ];
-multimodalModelQ[ other_ ] := With[ { name = toModelName @ other }, multimodalModelQ @ name /; StringQ @ name ];
+
+multimodalModelQ[ "gpt-4-turbo" ] :=
+    True;
+
+multimodalModelQ[ name_String? StringQ ] /; StringStartsQ[ name, "claude-3" ] :=
+    True;
+
+multimodalModelQ[ name_String? StringQ ] /; StringStartsQ[ name, "gpt-4-turbo-" ] :=
+    StringMatchQ[ name, "gpt-4-turbo-"~~DatePattern @ { "Year", "Month", "Day" } ];
+
+multimodalModelQ[ name_String? StringQ ] :=
+    StringContainsQ[ toModelName @ name, "gpt-"~~$$modelVersion~~"-vision" ];
+
+multimodalModelQ[ KeyValuePattern[ "Multimodal" -> multimodal_ ] ] :=
+    TrueQ @ multimodal;
+
+multimodalModelQ[ other_ ] :=
+    With[ { name = toModelName @ other },
+        multimodalModelQ @ name /; StringQ @ name
+    ];
+
 multimodalModelQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
This update adds support for Claude 3 models, which includes multimodal support:

![image](https://github.com/WolframResearch/Chatbook/assets/6674723/c73608a0-0678-4645-a03f-872f8aa6b58e)

Claude 3 models will show up in the menu and available to use once the relevant service connection is released.