### PR TITLE
Improved tool call prompting and switch to gpt-4o as default

### DIFF
--- a/Source/Chatbook/ChatHistory.wl
+++ b/Source/Chatbook/ChatHistory.wl
@@ -190,6 +190,8 @@ chatExcludedQ[ KeyValuePattern[ "ChatNotebookSettings" -> settings_ ] ] := chatE
 chatExcludedQ[ KeyValuePattern[ "ExcludeFromChat" -> exclude_ ] ] := TrueQ @ exclude;
 chatExcludedQ[ KeyValuePattern[ { } ] ] := False;
 chatExcludedQ[ Inherited ] := False;
+chatExcludedQ[ _? FailureQ ] := False;
+chatExcludedQ[ _FrontEnd`AbsoluteCurrentValue ] := False;
 
 chatExcludedQ // endDefinition;
 

--- a/Source/Chatbook/FrontEnd.wl
+++ b/Source/Chatbook/FrontEnd.wl
@@ -304,14 +304,17 @@ cellInformation // beginDefinition;
 
 cellInformation[ nbo_NotebookObject ] := cellInformation @ Cells @ nbo;
 
-cellInformation[ cells: { ___CellObject } ] := Map[
-    Association,
-    Transpose @ {
-        Developer`CellInformation @ cells,
-        Thread[ "CellObject"           -> cells ],
-        Thread[ "CellAutoOverwrite"    -> CurrentValue[ cells, CellAutoOverwrite ] ],
-        Thread[ "ChatNotebookSettings" -> AbsoluteCurrentValue[ cells, { TaggingRules, "ChatNotebookSettings" } ] ]
-    }
+cellInformation[ cells: { ___CellObject } ] := Select[
+    Map[
+        Association,
+        Transpose @ {
+            Developer`CellInformation @ cells,
+            Thread[ "CellObject"           -> cells ],
+            Thread[ "CellAutoOverwrite"    -> CurrentValue[ cells, CellAutoOverwrite ] ],
+            Thread[ "ChatNotebookSettings" -> AbsoluteCurrentValue[ cells, { TaggingRules, "ChatNotebookSettings" } ] ]
+        }
+    ],
+    AssociationQ
 ];
 
 cellInformation[ cell_CellObject ] := Association[

--- a/Source/Chatbook/Prompting.wl
+++ b/Source/Chatbook/Prompting.wl
@@ -53,7 +53,9 @@ $basePromptOrder = {
     "ModernMethods",
     "FunctionalStyle",
     "WolframLanguageStyle",
-    "WolframLanguageEvaluatorTool"
+    "WolframLanguageEvaluatorTool",
+    "EndTurnToken",
+    "EndTurnToolCall"
 };
 
 $basePromptClasses = <|
@@ -98,7 +100,9 @@ $basePromptDependencies = Append[ "GeneralInstructionsHeader" ] /@ <|
     "ModernMethods"                -> { },
     "FunctionalStyle"              -> { },
     "WolframLanguageStyle"         -> { "DocumentationLinkSyntax", "InlineSymbolLinks" },
-    "WolframLanguageEvaluatorTool" -> { "WolframLanguageStyle" }
+    "WolframLanguageEvaluatorTool" -> { "WolframLanguageStyle" },
+    "EndTurnToken"                 -> { },
+    "EndTurnToolCall"              -> { "EndTurnToken" }
 |>;
 
 (* ::**************************************************************************************************************:: *)
@@ -255,6 +259,12 @@ $basePromptComponents[ "WolframLanguageStyle" ] = "
 
 $basePromptComponents[ "WolframLanguageEvaluatorTool" ] = "\
 * If the user is asking for a result instead of code to produce that result, use the wolfram_language_evaluator tool";
+
+$basePromptComponents[ "EndTurnToken" ] = "\
+* Always end your turn by writing /end.";
+
+$basePromptComponents[ "EndTurnToolCall" ] = "\
+* If you are going to make a tool call, you must do so BEFORE ending your turn.";
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -31,6 +31,20 @@ Needs[ "Wolfram`Chatbook`Prompting`"    ];
 Needs[ "Wolfram`Chatbook`Tools`"        ];
 Needs[ "Wolfram`Chatbook`Utils`"        ];
 
+(* TODO:
+
+    There should be a way to pass custom serialization rules in chat settings, e.g.
+    ```
+    "ConversionRules" -> {
+        _GraphicsBox -> "[Image]",
+        Cell[box_, "MyStyle"] :> formatMyStyle[box]
+    }
+    ```
+
+    These replacements should be done prior to calling `cellToString`, but need to be tagged in some way so we don't
+    try to serialize the results again via `fasterCellToString0`.
+*)
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Initialization*)

--- a/Source/Chatbook/Tools/DefaultTools.wl
+++ b/Source/Chatbook/Tools/DefaultTools.wl
@@ -1041,8 +1041,11 @@ $fullExamples :=
     With[ { keys = $fullExamplesKeys },
         If[ keys === { },
             "",
+            needsBasePrompt[ "EndTurnToolCall" ];
             StringJoin[
-                "## Full examples\n\n---\n\n",
+                "## Full examples\n\n",
+                "The following are brief conversation examples that demonstrate how you can use tools in a ",
+                "conversation with the user.\n\n---\n\n",
                 StringRiffle[ Values @ KeyTake[ $fullExamples0, $fullExamplesKeys ], "\n\n---\n\n" ],
                 "\n\n---\n"
             ]
@@ -1083,173 +1086,261 @@ $fullExamples0 = <| |>;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*Example Templates*)
+$chatMessageTemplates = <| |>;
+$messageTemplateType  = "Basic";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Basic*)
+$chatMessageTemplates[ "Basic" ] = <| |>;
+$chatMessageTemplates[ "Basic", "User"      ] = "User: %%1%%";
+$chatMessageTemplates[ "Basic", "Assistant" ] = "Assistant: %%1%%\n/end";
+$chatMessageTemplates[ "Basic", "System"    ] = "System: %%1%%";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Instruct*)
+$chatMessageTemplates[ "Instruct" ] = <| |>;
+$chatMessageTemplates[ "Instruct", "User"      ] = "[INST]%%1%%[/INST]";
+$chatMessageTemplates[ "Instruct", "Assistant" ] = "%%1%%\n/end";
+$chatMessageTemplates[ "Instruct", "System"    ] = "[INST]%%1%%[/INST]";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Zephyr*)
+$chatMessageTemplates[ "Zephyr" ] = <| |>;
+$chatMessageTemplates[ "Zephyr", "User"      ] = "<|user|>\n%%1%%</s>";
+$chatMessageTemplates[ "Zephyr", "Assistant" ] = "<|assistant|>\n%%1%%/end";
+$chatMessageTemplates[ "Zephyr", "System"    ] = "<|system|>\n%%1%%</s>";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*Boxed*)
+$chatMessageTemplates[ "Boxed" ] = <| |>;
+$chatMessageTemplates[ "Boxed", "User"      ] = "[user]\n%%1%%";
+$chatMessageTemplates[ "Boxed", "Assistant" ] = "[assistant]\n%%1%%\n/end";
+$chatMessageTemplates[ "Boxed", "System"    ] = "[system]\n%%1%%";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*ChatML*)
+$chatMessageTemplates[ "ChatML" ] = <| |>;
+$chatMessageTemplates[ "ChatML", "User"      ] = "<|im_start|>user\n%%1%%<|im_end|>";
+$chatMessageTemplates[ "ChatML", "Assistant" ] = "<|im_start|>assistant\n%%1%%\n/end<|im_end|>";
+$chatMessageTemplates[ "ChatML", "System"    ] = "<|im_start|>system\n%%1%%<|im_end|>";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*XML*)
+$chatMessageTemplates[ "XML" ] = <| |>;
+$chatMessageTemplates[ "XML", "User"      ] = "<user>%%1%%</user>";
+$chatMessageTemplates[ "XML", "Assistant" ] = "<assistant>%%1%%\n/end</assistant>";
+$chatMessageTemplates[ "XML", "System"    ] = "<system>%%1%%</system>";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*messageTemplate*)
+messageTemplate // beginDefinition;
+
+messageTemplate[ id_String ] := Enclose[
+    StringTemplate[
+        ConfirmBy[ $chatMessageTemplates[ $messageTemplateType, id ], StringQ, "TemplateString" ],
+        Delimiters -> "%%"
+    ],
+    throwInternalFailure
+];
+
+messageTemplate // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*user*)
+user // beginDefinition;
+user[ a_List ] := TemplateApply[ messageTemplate[ "User" ], StringRiffle[ TextString /@ Flatten @ a, "\n" ] ];
+user[ a_String ] := user @ { a };
+user // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*assistant*)
+assistant // beginDefinition;
+assistant[ { a___, "tool" -> { name_String, as_Association }, b___ } ] := assistant @ { a, toolCall[ name, as ], b };
+assistant[ a_List ] := TemplateApply[ messageTemplate[ "Assistant" ], StringRiffle[ TextString /@ Flatten @ a, "\n" ] ];
+assistant[ a_String ] := assistant @ { a };
+assistant // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*system*)
+system // beginDefinition;
+system[ a_List ] := TemplateApply[ messageTemplate[ "System" ], StringRiffle[ TextString /@ Flatten @ a, "\n" ] ];
+system[ a_String ] := system @ { a };
+system // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*toolCall*)
+toolCall // beginDefinition;
+toolCall[ args__ ] := formatToolCallExample @ args;
+toolCall // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*toolExample*)
+toolExample // beginDefinition;
+toolExample[ rules: (_Rule|_String).. ] := StringRiffle[ toolExample0 /@ { rules }, "\n\n" ];
+toolExample // endDefinition;
+
+toolExample0 // beginDefinition;
+toolExample0[ "user"      -> message_ ] := user      @ message;
+toolExample0[ "assistant" -> message_ ] := assistant @ message;
+toolExample0[ "system"    -> message_ ] := system    @ message;
+toolExample0[ prompt_String           ] := prompt;
+toolExample0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*AstroGraphicsDocumentation*)
-$fullExamples0[ "AstroGraphicsDocumentation" ] = TemplateApply[ "\
-[user]
-How do I use AstroGraphics?
-
-[assistant]
-Let me check the documentation for you. One moment...
-`1`
-
-[system]
-Usage
-AstroGraphics[primitives, options] represents a two-dimensional view of space and the celestial sphere.
-
-Basic Examples
-...
-
-[assistant]
-To use [AstroGraphics](paclet:ref/AstroGraphics), you need to provide a list of graphics primitives and options. \
-For example, ...",
-{
-    formatToolCallExample[ "DocumentationLookup", <| "names" -> "AstroGraphics" |> ]
-} ];
+$fullExamples0[ "AstroGraphicsDocumentation" ] := toolExample[
+    "user" -> "How do I use AstroGraphics?",
+    "assistant" -> {
+        "Let me check the documentation for you. One moment...",
+        "tool" -> { "DocumentationLookup", <| "names" -> "AstroGraphics" |> }
+    },
+    "system" -> {
+        "Usage",
+        "AstroGraphics[primitives, options] represents a two-dimensional view of space and the celestial sphere.",
+        "",
+        "Basic Examples",
+        "..."
+    },
+    "assistant" -> "To use [AstroGraphics](paclet:ref/AstroGraphics), you need to..."
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*NaturalLanguageInput*)
-$fullExamples0[ "NaturalLanguageInput" ] = "\
-[user]
-How far away is NYC from Boston?
-
-[assistant]
-"<>formatToolCallExample[
-    "WolframLanguageEvaluator",
-    <|
-        "code" -> "GeoDistance[\[FreeformPrompt][\"Boston, MA\"], \[FreeformPrompt][\"New York City\"]]"
-    |>
-]<>"
-
-[system]
-Quantity[164.41, \"Miles\"]
-
-[assistant]
-It's 164.41 miles from Boston to New York City.
-
-[user]
-If I made the trip in 3h 17m, how fast was I going?
-
-[assistant]
-"<>formatToolCallExample[
-    "WolframLanguageEvaluator",
-    <| "code" -> "\[FreeformPrompt][\"164.41 Miles\"] / \[FreeformPrompt][\"3h 17m\"]" |>
-]<>"\
-
-[system]
-Quantity[50.071, \"Miles\" / \"Hours\"]
-
-[assistant]
-You were going 50.071 miles per hour.
-
-[user]
-What time would I arrive if I left right now?
-
-[assistant]
-"<>formatToolCallExample[
-    "WolframLanguageEvaluator",
-    <| "code" -> "\[FreeformPrompt][\"3h 17m from now\"]" |>
+$fullExamples0[ "NaturalLanguageInput" ] := toolExample[
+    "user" -> "How far away is NYC from Boston?",
+    "assistant" -> {
+        "tool" -> {
+            "WolframLanguageEvaluator",
+            <| "code" -> "GeoDistance[\[FreeformPrompt][\"Boston, MA\"], \[FreeformPrompt][\"New York City\"]]" |>
+        }
+    },
+    "system" -> "Quantity[164.41, \"Miles\"]",
+    "assistant" -> "It's 164.41 miles from Boston to New York City.",
+    "user" -> "If I made the trip in 3h 17m, how fast was I going?",
+    "assistant" -> {
+        "tool" -> {
+            "WolframLanguageEvaluator",
+            <| "code" -> "\[FreeformPrompt][\"164.41 Miles\"] / \[FreeformPrompt][\"3h 17m\"]" |>
+        }
+    },
+    "system" -> "Quantity[50.071, \"Miles\" / \"Hours\"]",
+    "assistant" -> "You were going 50.071 miles per hour.",
+    "user" -> "What time would I arrive if I left right now?",
+    "assistant" -> {
+        "tool" -> {
+            "WolframLanguageEvaluator",
+            <| "code" -> "\[FreeformPrompt][\"3h 17m from now\"]" |>
+        }
+    }
 ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*FileSystemTree*)
-$fullExamples0[ "FileSystemTree" ] = "\
-[user]
-What's the best way to generate a tree of files in a given directory?
-
-[assistant]
-"<>formatToolCallExample[ "DocumentationSearcher", <| "query" -> "tree of files" |> ]<>"
-
-[system]
-* FileSystemTree - (score: 9.9) FileSystemTree[root] gives a tree whose keys are ...
-* Tree Drawing - (score: 3.0) ...
-
-[assistant]
-"<>formatToolCallExample[ "DocumentationLookup", <| "names" -> "FileSystemTree" |> ]<>"
-
-...";
+$fullExamples0[ "FileSystemTree" ] := toolExample[
+    "user" -> "What's the best way to generate a tree of files in a given directory?",
+    "assistant" -> {
+        "tool" -> { "DocumentationSearcher", <| "query" -> "tree of files" |> }
+    },
+    "system" -> {
+        "* FileSystemTree - (score: 9.9) FileSystemTree[root] gives a tree whose keys are ...",
+        "* Tree Drawing - (score: 3.0) ..."
+    },
+    "assistant" -> {
+        "tool" -> { "DocumentationLookup", <| "names" -> "FileSystemTree" |> }
+    },
+    "..."
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*FractionalDerivatives*)
-$fullExamples0[ "FractionalDerivatives" ] = "\
-[user]
-Calculate the half-order fractional derivative of x^n with respect to x.
-
-[assistant]
-"<>formatToolCallExample[ "DocumentationSearcher", <| "query" -> "fractional derivatives" |> ]<>"
-
-[system]
-* FractionalD - (score: 9.5) FractionalD[f, {x, a}] gives ...
-* NFractionalD - (score: 9.2) ...
-
-[assistant]
-"<>formatToolCallExample[ "DocumentationLookup", <| "names" -> "FractionalD" |> ]<>"
-
-[system]
-Usage
-FractionalD[f, {x, a}] gives the Riemann-Liouville fractional derivative D_x^a f(x) of order a of the function f.
-
-Basic Examples
-<example text>
-
-[assistant]
-"<>formatToolCallExample[ "WolframLanguageEvaluator", <| "code" -> "FractionalD[x^n, {x, 1/2}]" |> ]<>"
-
-[system]
-Out[n]= Piecewise[...]
-
-![Formatted Result](expression://content-{id})
-
-[assistant]
-The half-order fractional derivative of $$x^n$$ with respect to $$x$$ is given by:
-![Fractional Derivative](expression://content-{id})
-";
+$fullExamples0[ "FractionalDerivatives" ] := toolExample[
+    "user" -> "Calculate the half-order fractional derivative of x^n with respect to x.",
+    "assistant" -> {
+        "tool" -> { "DocumentationSearcher", <| "query" -> "fractional derivatives" |> }
+    },
+    "system" -> {
+        "* FractionalD - (score: 9.5) FractionalD[f, {x, a}] gives ...",
+        "* NFractionalD - (score: 9.2) ..."
+    },
+    "assistant" -> {
+        "tool" -> { "DocumentationLookup", <| "names" -> "FractionalD" |> }
+    },
+    "system" -> {
+        "Usage",
+        "FractionalD[f, {x, a}] gives the Riemann-Liouville fractional derivative D_x^a f(x) of order a of the function f.",
+        "",
+        "Basic Examples",
+        "..."
+    },
+    "assistant" -> {
+        "tool" -> {
+            "WolframLanguageEvaluator",
+            <| "code" -> "FractionalD[x^n, {x, 1/2}]" |>
+        }
+    },
+    "system" -> {
+        "Out[n]= Piecewise[...]\n",
+        "![Formatted Result](expression://content-{id})"
+    },
+    "assistant" -> {
+        "The half-order fractional derivative of $$x^n$$ with respect to $$x$$ is given by:",
+        "![Fractional Derivative](expression://content-{id})"
+    }
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*PlotEvaluate*)
-$fullExamples0[ "PlotEvaluate" ] = StringJoin[ "\
-[user]
-Plot sin(x) from -5 to 5
-
-[assistant]
-", formatToolCallExample[
-    "WolframLanguageEvaluator",
-    <| "code" -> "Plot[Sin[x], {x, -5, 5}, AxesLabel -> {\"x\", \"sin(x)\"}]" |>
-], "
-
-[system]
-Out[n]= ![image](attachment://content-{id})
-
-[assistant]
-Here's the plot of $$\\sin{x}$$ from -5 to 5:
-![Plot](attachment://content-{id})"
+$fullExamples0[ "PlotEvaluate" ] := toolExample[
+    "user" -> "Plot sin(x) from -5 to 5",
+    "assistant" -> {
+        "tool" -> {
+            "WolframLanguageEvaluator",
+            <| "code" -> "Plot[Sin[x], {x, -5, 5}, AxesLabel -> {\"x\", \"sin(x)\"}" |>
+        }
+    },
+    "system" -> "Out[n]= ![image](attachment://content-{id})",
+    "assistant" -> {
+        "Here's the plot of $$\\sin{x}$$ from -5 to 5:",
+        "![Plot](attachment://content-{id})"
+    }
 ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
 (*TemporaryDirectory*)
-$fullExamples0[ "TemporaryDirectory" ] = "\
-[user]
-Where is the temporary directory located?
-
-[assistant]
-"<>formatToolCallExample[ "DocumentationSearcher", <| "query" -> "location of temporary directory" |> ]<>"
-
-[system]
-* $TemporaryDirectory - (score: 9.6) $TemporaryDirectory gives the main system directory for temporary files.
-* CreateDirectory - (score: 8.5) CreateDirectory[\"dir\"] creates ...
-
-[assistant]
-"<>formatToolCallExample[ "WolframLanguageEvaluator", <| "code" -> "$TemporaryDirectory" |> ]<>"
-
-[system]
-Out[n]= \"C:\\Users\\UserName\\AppData\\Local\\Temp\"
-
-[assistant]
-The temporary directory is located at C:\\Users\\UserName\\AppData\\Local\\Temp.";
+$fullExamples0[ "TemporaryDirectory" ] := toolExample[
+    "user" -> "Where is the temporary directory located?",
+    "assistant" -> {
+        "tool" -> { "DocumentationSearcher", <| "query" -> "location of temporary directory" |> }
+    },
+    "system" -> {
+        "* $TemporaryDirectory - (score: 9.6) $TemporaryDirectory gives the main system directory for temporary files.",
+        "* CreateDirectory - (score: 8.5) CreateDirectory[\"dir\"] creates ..."
+    },
+    "assistant" -> {
+        "tool" -> { "WolframLanguageEvaluator", <| "code" -> "$TemporaryDirectory" |> }
+    },
+    "system" -> "Out[n]= \"C:\\Users\\UserName\\AppData\\Local\\Temp\"",
+    "assistant" -> "The temporary directory is located at C:\\Users\\UserName\\AppData\\Local\\Temp."
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)


### PR DESCRIPTION
* Added "ToolCallExamplePromptStyle" setting, which controls the formatting of tool call example prompts
* Try to use "Simple" tool call method when possible, since it doesn't have the laziness issue that the full JSON spec has
* Fixed another unhandled argument in `chatExcludedQ`
* Fixed a bug in `cellInformation` when a deleted cell object is given
* Added stop token and prompting about ending messages