### PR TITLE
Bugfix: Prevent `ShowStringCharacters` message for partial strings in code blocks

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -2578,7 +2578,7 @@ stringToBoxes[ s_String /; StringMatchQ[ s, "\"" ~~ __ ~~ "\"" ] ] :=
     With[ { str = stringToBoxes @ StringTrim[ s, "\"" ] }, "\""<>str<>"\"" /; StringQ @ str ];
 
 stringToBoxes[ s_String ] :=
-    adjustBoxSpacing @ stringToBoxes0 @ usingFrontEnd @ MathLink`CallFrontEnd @ FrontEnd`ReparseBoxStructurePacket @ s;
+    adjustBoxSpacing @ stringToBoxes0 @ reparseBoxStructurePacket @ s;
 
 stringToBoxes // endDefinition;
 
@@ -2586,6 +2586,21 @@ stringToBoxes // endDefinition;
 stringToBoxes0 // beginDefinition;
 stringToBoxes0[ boxes_? boxDataQ ] := boxes;
 stringToBoxes0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*reparseBoxStructurePacket*)
+reparseBoxStructurePacket // beginDefinition;
+
+reparseBoxStructurePacket[ string_String ] := Replace[
+    usingFrontEnd @ MathLink`CallFrontEnd @ FrontEnd`ReparseBoxStructurePacket @ StyleBox[
+        string,
+        ShowStringCharacters -> False
+    ],
+    StyleBox[ boxes_, ___ ] :> boxes
+];
+
+reparseBoxStructurePacket // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -2595,7 +2595,7 @@ reparseBoxStructurePacket // beginDefinition;
 reparseBoxStructurePacket[ string_String ] := Replace[
     usingFrontEnd @ MathLink`CallFrontEnd @ FrontEnd`ReparseBoxStructurePacket @ StyleBox[
         string,
-        ShowStringCharacters -> False
+        ShowStringCharacters -> True
     ],
     StyleBox[ boxes_, ___ ] :> boxes
 ];


### PR DESCRIPTION
This fixes the message that appears in the messages window when writing a chat output that has unbalanced quotes in code blocks:

<img width="605" alt="image" src="https://github.com/user-attachments/assets/af897357-f472-461a-bb6b-efb1b4adb0f5">
