### PR TITLE
Bugfix: Fix several version compatibility issues

### DIFF
--- a/Source/Chatbook/PreferencesContent.wl
+++ b/Source/Chatbook/PreferencesContent.wl
@@ -472,6 +472,9 @@ makeModelSelector0[ services_Association? AssociationQ ] := Enclose[
     throwInternalFailure
 ];
 
+makeModelSelector0[ failure: HoldPattern @ Failure[ LLMServices`LLMServiceInformation, ___ ] ] :=
+    Pane[ failure, ImageSize -> { $preferencesWidth-50, Automatic } ];
+
 makeModelSelector0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -1084,8 +1087,12 @@ makeToolCallFrequencySelector // endDefinition;
 (* ::Subsection::Closed:: *)
 (*servicesSettingsPanel*)
 servicesSettingsPanel // beginDefinition;
+servicesSettingsPanel[ ] := Catch[ servicesSettingsPanel0[ ], $servicesSettingsTag ];
+servicesSettingsPanel // endDefinition;
 
-servicesSettingsPanel[ ] := Enclose[
+servicesSettingsPanel0 // beginDefinition;
+
+servicesSettingsPanel0[ ] := Enclose[
     Module[ { settingsLabel, settings, serviceGrid },
 
         settingsLabel = subsectionText @ tr[ "PreferencesContentSubsectionRegisteredServices" ];
@@ -1109,7 +1116,7 @@ servicesSettingsPanel[ ] := Enclose[
     throwInternalFailure
 ];
 
-servicesSettingsPanel // endDefinition;
+servicesSettingsPanel0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
@@ -1128,7 +1135,7 @@ makeServiceGrid[ ] := Grid[
                 Spacer[ 1 ]
             }
         },
-        KeyValueMap[ makeServiceGridRow, DeleteCases[ $availableServices, KeyValuePattern[ "Hidden" -> True ] ] ]
+        makeServiceGridRows @ $availableServices
     ],
     Alignment  -> { Left, Baseline },
     Background -> { { }, { GrayLevel[ 0.898 ], { White } } },
@@ -1139,6 +1146,19 @@ makeServiceGrid[ ] := Grid[
 ];
 
 makeServiceGrid // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*makeServiceGridRows*)
+makeServiceGridRows // beginDefinition;
+
+makeServiceGridRows[ services_Association ] :=
+    KeyValueMap[ makeServiceGridRow, DeleteCases[ services, KeyValuePattern[ "Hidden" -> True ] ] ];
+
+makeServiceGridRows[ failure: HoldPattern @ Failure[ LLMServices`LLMServiceInformation, ___ ] ] :=
+    Throw[ Pane[ failure, ImageSize -> { $preferencesWidth-50, Automatic } ], $servicesSettingsTag ];
+
+makeServiceGridRows // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/ToolManager.wl
+++ b/Source/Chatbook/ToolManager.wl
@@ -459,7 +459,7 @@ getFullPersonaList // endDefinition;
 standardizePersonaData // beginDefinition;
 
 standardizePersonaData[ persona_Association ] :=
-    standardizePersonaData[ persona, Lookup[ persona, "Tools", { } ] ];
+    standardizePersonaData[ persona, getValidPersonaTools @ persona ];
 
 standardizePersonaData[ persona_Association, tools_List ] :=
     Append[ persona, "Tools" -> tools ];
@@ -471,6 +471,13 @@ standardizePersonaData[ persona_Association, None ] :=
     standardizePersonaData[ persona, { } ];
 
 standardizePersonaData // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*getValidPersonaTools*)
+getValidPersonaTools // beginDefinition;
+getValidPersonaTools[ persona_Association ] := Quiet @ Cases[ Lookup[ persona, "Tools", { } ], _LLMTool ];
+getValidPersonaTools // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Tools/Common.wl
+++ b/Source/Chatbook/Tools/Common.wl
@@ -161,7 +161,10 @@ reevaluateToolExpressions // endDefinition;
 (*Installed Tools*)
 $installedTools := Association @ Cases[
     GetInstalledResourceData[ "LLMTool" ],
-    as: KeyValuePattern[ "Tool" -> tool_ ] :> (toolName @ tool -> addExtraToolData[ tool, as ])
+    as: KeyValuePattern[ "Tool" -> tool0_ ] :>
+        With[ { tool = Quiet @ tool0 },
+            (toolName @ tool -> addExtraToolData[ tool, as ]) /; MatchQ[ tool, _LLMTool ]
+        ]
 ];
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
* Try to reset services when data is corrupt rather than fail with an internal error.
* Display the underlying `Failure[...]` as a fallback in the preferences UI if resetting also fails.
* Ignore `LLMTool[...]` expressions that were created/installed in later versions of WL that fail when evaluated.