### PR TITLE
Bugfix: The latest snapshot of gpt-4o is really bad at textual tool calling

### DIFF
--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -287,10 +287,25 @@ resolveAutoSettings0 // endDefinition;
 (*overrideSettings*)
 overrideSettings // beginDefinition;
 overrideSettings[ settings_Association? o1ModelQ ] := <| settings, $o1Overrides |>;
+overrideSettings[ settings_Association? gpt4oTextToolsQ ] := <| settings, $gpt4oTextToolOverrides |>;
 overrideSettings[ settings_Association ] := settings;
 overrideSettings // endDefinition;
 
 $o1Overrides = <| "PresencePenalty" -> 0, "Temperature" -> 1 |>;
+$gpt4oTextToolOverrides = <| "Model" -> <| "Service" -> "OpenAI", "Name" -> "gpt-4o-2024-05-13" |> |>;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsubsection::Closed:: *)
+(*gpt4oTextToolsQ*)
+gpt4oTextToolsQ // beginDefinition;
+
+gpt4oTextToolsQ[ settings_Association ] := TrueQ @ And[
+    settings[ "ToolsEnabled" ],
+    toModelName @ settings === "gpt-4o",
+    settings[ "ToolMethod" ] =!= "Service"
+];
+
+gpt4oTextToolsQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)


### PR DESCRIPTION
With this change, the model "gpt-4o" with no date specified will be resolved as "gpt-4o-2024-05-13" when text-based tool calling is enabled:
```
In[1]:= CurrentChatSettings[$FrontEnd, "Model"]
Out[1]= <|"Service" -> "OpenAI", "Name" -> "gpt-4o"|>
```
```
In[2]:= AbsoluteCurrentChatSettings[$FrontEnd, "Model"]
Out[2]= <|"Service" -> "OpenAI", "Name" -> "gpt-4o-2024-05-13"|>
```