### PR TITLE
Bugfix: GPT-4o often writes tool calls in a partial code block

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -1103,12 +1103,18 @@ $textDataFormatRules = {
         Longest[ "```" ~~ language: Except[ "\n" ]... ] ~~ (" "...) ~~ "\n",
         Shortest[ code__ ],
         ("```"|EndOfString)
-    ] /; StringFreeQ[ code, "TOOLCALL:" ~~ ___ ~~ ($$endToolCall|EndOfString) ] :>
+    ] /; StringFreeQ[ code, ("TOOLCALL:" ~~ ___ ~~ ($$endToolCall|EndOfString))|$$simpleToolCall ] :>
         codeBlockCell[ language, code ]
     ,
-    tool: ("TOOLCALL:" ~~ Shortest[ ___ ] ~~ ($$endToolCall|EndOfString)) :> inlineToolCallCell @ tool
+    Longest @ StringExpression[
+        (("```" ~~ Except[ "\n" ]... ~~ (" "...) ~~ "\n"))|"",
+        tool: ("TOOLCALL:" ~~ Shortest[ ___ ] ~~ ($$endToolCall|EndOfString))
+    ] :> inlineToolCallCell @ tool
     ,
-    tool: $$simpleToolCall :> inlineToolCallCell @ tool
+    Longest @ StringExpression[
+        (("```" ~~ Except[ "\n" ]... ~~ (" "...) ~~ "\n"))|"",
+        tool: $$simpleToolCall
+     ] :> inlineToolCallCell @ tool
     ,
     StartOfLine ~~ "/retry" ~~ (WhitespaceCharacter|EndOfString) :> $discardPreviousToolCall
     ,


### PR DESCRIPTION
This fixes an issue where the LLM sometimes incorrectly starts a code block before a tool call (and never closes it), resulting in raw tool call text appearing in the output:

![image](https://github.com/user-attachments/assets/ac62c920-8114-4330-aecf-925f982e10b5)