### PR TITLE
Added `$LastChatbookFailure` and `$LastChatbookFailureText` for easier bug reporting

### DIFF
--- a/Source/Chatbook/Main.wl
+++ b/Source/Chatbook/Main.wl
@@ -29,6 +29,8 @@ BeginPackage[ "Wolfram`Chatbook`" ];
 `$IncludedCellWidget;
 `$InlineChat;
 `$InstalledTools;
+`$LastChatbookFailure;
+`$LastChatbookFailureText;
 `$SandboxKernel;
 `$ToolFunctions;
 `$WorkspaceChat;
@@ -190,6 +192,8 @@ $ChatbookProtectedNames = "Wolfram`Chatbook`" <> # & /@ {
     "$DefaultTools",
     "$InlineChat",
     "$InstalledTools",
+    "$LastChatbookFailure",
+    "$LastChatbookFailureText",
     "$ToolFunctions",
     "$WorkspaceChat",
     "AbsoluteCurrentChatSettings",


### PR DESCRIPTION
* Fixed an issue where bug report URLs could have invalid percent-encoded characters
* Prioritize failure info so most important data is less likely to be truncated
* Reverse stack trace to avoid truncating important items
* Increase the allowed size of bug report text