### PR TITLE
Show progress text for non streaming models

### DIFF
--- a/.github/workflows/ExperimentalRelease.yml
+++ b/.github/workflows/ExperimentalRelease.yml
@@ -2,8 +2,8 @@ name: Experimental Release
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 3 * * *'
+  push:
+    branches: [main]
 
 concurrency:
   group: ${{ github.ref }}

--- a/Source/Chatbook/ChatState.wl
+++ b/Source/Chatbook/ChatState.wl
@@ -32,6 +32,7 @@ withChatState[ eval_ ] :=
             $toolCallCount                = 0,
             $openToolCallBoxes            = Automatic,
             $progressContainer            = None,
+            $showProgressText             = $showProgressText,
 
             (* Values used for token budgets during cell serialization: *)
             $cellStringBudget             = $cellStringBudget,

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -547,6 +547,7 @@ chatSubmit0[
         auth = settings[ "Authentication" ];
         stop = makeStopTokens @ settings;
 
+        setProgressDisplay[ "Waiting for response", 1.0 ];
         result = ConfirmMatch[
             Quiet[
                 LLMServices`Chat[

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -258,6 +258,8 @@ resolveAutoSettings[ settings0_Association ] := Enclose[
             $conversionRules         = resolved[ "ConversionRules" ];
             $openToolCallBoxes       = resolved[ "OpenToolCallBoxes" ];
 
+            If[ resolved[ "ForceSynchronous" ], $showProgressText = True ];
+
             setLLMKitFlags @ resolved;
         ];
         If[ $catching, $currentChatSettings = resolved ];


### PR DESCRIPTION
This makes it clear that slow synchronous models like o1-preview are doing their thing instead of there being a hang:
![Screenshot 2024-10-31 195502](https://github.com/user-attachments/assets/6aa50836-9c17-4250-ac41-d086c004f3a0)
