### PR TITLE
Bugfix: Align chat icons to cell baseline instead of centering vertically

### DIFF
--- a/Developer/Resources/WorkspaceStyles.wl
+++ b/Developer/Resources/WorkspaceStyles.wl
@@ -65,6 +65,8 @@ Cell[
     CellFrame             -> 0,
     CellFrameLabelMargins -> -15,
     CellMargins           -> { { 15, 15 }, { 5, 10 } },
+    FrameBoxOptions       -> { BaselinePosition -> Baseline },
+    PaneBoxOptions        -> { BaselinePosition -> Baseline },
     Selectable            -> False,
     ShowCellBracket       -> False,
     CellFrameLabels       -> {
@@ -79,7 +81,8 @@ Cell[
                     ],
                     SingleEvaluation -> True
                 ],
-                Background -> None
+                Background   -> None,
+                CellBaseline -> Baseline
             ]
         },
         { None, None }
@@ -96,7 +99,9 @@ Cell[
     CellFrame             -> 0,
     CellFrameLabelMargins -> -5,
     CellMargins           -> { { 10, 15 }, { 25, 12 } },
+    FrameBoxOptions       -> { BaselinePosition -> Baseline },
     Initialization        -> None,
+    PaneBoxOptions        -> { BaselinePosition -> Baseline },
     Selectable            -> False,
     ShowCellBracket       -> False,
     CellFrameLabels       -> {
@@ -110,7 +115,8 @@ Cell[
                     ],
                     SingleEvaluation -> True
                 ],
-                Background -> None
+                Background   -> None,
+                CellBaseline -> Baseline
             ],
             None
         },

--- a/FrontEnd/Assets/Extensions/CoreExtensions.nb
+++ b/FrontEnd/Assets/Extensions/CoreExtensions.nb
@@ -11,7 +11,7 @@ Notebook[
   Cell["Chatbook Core.nb Extensions", "Title"],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3939536254"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3940147331"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -828,7 +828,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3939536254"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3940147331"|>
   ],
   Cell[
    StyleData["Text"],

--- a/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -74,7 +74,7 @@ Notebook[
   ],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "1.5.2.3939536254"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "1.5.2.3940147331"|>
   ],
   Cell[
    StyleData[
@@ -118,12 +118,15 @@ Notebook[
         SingleEvaluation -> True
        ]
       ],
-      Background -> None
+      Background -> None,
+      CellBaseline -> Baseline
      ]
     },
     {None, None}
    },
-   CellFrameLabelMargins -> -15
+   CellFrameLabelMargins -> -15,
+   FrameBoxOptions -> {BaselinePosition -> Baseline},
+   PaneBoxOptions -> {BaselinePosition -> Baseline}
   ],
   Cell[
    StyleData["ChatOutput"],
@@ -148,14 +151,17 @@ Notebook[
         SingleEvaluation -> True
        ]
       ],
-      Background -> None
+      Background -> None,
+      CellBaseline -> Baseline
      ],
      None
     },
     {None, None}
    },
    CellFrameLabelMargins -> -5,
-   Background -> None
+   Background -> None,
+   FrameBoxOptions -> {BaselinePosition -> Baseline},
+   PaneBoxOptions -> {BaselinePosition -> Baseline}
   ],
   Cell[
    StyleData["ChatInputField"],


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5f833f70-dd75-4a8c-840c-6b7c893b870d)
