### PR TITLE
Fix line wrap indentation for inline item cells

### DIFF
--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -1168,6 +1168,29 @@ Cell[
 ]
 
 
+
+(* ::Subsection::Closed:: *)
+(*InlineItem*)
+
+
+Cell[
+    StyleData[ "InlineItem" ],
+    ParagraphIndent -> -10
+]
+
+
+
+(* ::Subsection::Closed:: *)
+(*InlineSubitem*)
+
+
+Cell[
+    StyleData[ "InlineSubitem" ],
+    ParagraphIndent -> -16
+]
+
+
+
 (* ::Subsection::Closed:: *)
 (*DropShadowPaneBox*)
 

--- a/FrontEnd/Assets/Extensions/CoreExtensions.nb
+++ b/FrontEnd/Assets/Extensions/CoreExtensions.nb
@@ -11,7 +11,7 @@ Notebook[
   Cell["Chatbook Core.nb Extensions", "Title"],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3940955540"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3941018585"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -13789,6 +13789,8 @@ Notebook[
      ])
    }
   ],
+  Cell[StyleData["InlineItem"], ParagraphIndent -> -10],
+  Cell[StyleData["InlineSubitem"], ParagraphIndent -> -16],
   Cell[
    StyleData["DropShadowPaneBox"],
    TemplateBoxOptions -> {

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -824,7 +824,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3940955540"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "1.5.2.3941018585"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -14661,6 +14661,8 @@ Notebook[
      ])
    }
   ],
+  Cell[StyleData["InlineItem"], ParagraphIndent -> -10],
+  Cell[StyleData["InlineSubitem"], ParagraphIndent -> -16],
   Cell[
    StyleData["DropShadowPaneBox"],
    TemplateBoxOptions -> {

--- a/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -83,7 +83,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "1.5.2.3940955540"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "1.5.2.3941018585"|>
   ],
   Cell[
    StyleData[


### PR DESCRIPTION
# Before

![image](https://github.com/user-attachments/assets/eb2d6ccf-05ad-4416-96f3-e8710b543771)


# After

![image](https://github.com/user-attachments/assets/c0b0c172-0766-4334-9370-32e77555181b)
