### PR TITLE
Bugfix: Handle grids that have more alignment specifications than columns

### DIFF
--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -1868,7 +1868,7 @@ createAlignedDelimiters[ colSizes_List, { a: Except[ { _ } ]..., { repeat_ }, b:
 createAlignedDelimiters[ colSizes_List, { alignment: Except[ _List ] } ] :=
     createAlignedDelimiters[ colSizes, ConstantArray[ alignment, Length @ colSizes ] ];
 
-createAlignedDelimiters[ colSizes_List, alignments_List ] /; Length @ alignments < Length @ colSizes :=
+createAlignedDelimiters[ colSizes_List, alignments_List ] /; Length @ alignments =!= Length @ colSizes :=
     createAlignedDelimiters[ colSizes, PadRight[ alignments, Length @ colSizes, Automatic ] ];
 
 createAlignedDelimiters // endDefinition;


### PR DESCRIPTION
# Before

![image](https://github.com/user-attachments/assets/d59bc24e-6efd-4536-820a-33e6f942a5a4)

# After

![image](https://github.com/user-attachments/assets/ade8db7b-a0a8-4be6-915d-82616e8c8d91)