### PR TITLE
Add NotebookOptions parameter to ShowNotebookAssistance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Assets/VectorDatabases/**/*.wxf
 build
 Developer/VectorDatabases/SourceData/*.jsonl
 Source/Chatbook/64Bit/Chatbook.mx
+.claude/


### PR DESCRIPTION
## Summary
- Added NotebookOptions parameter to ShowNotebookAssistance to allow customization of created notebooks
- Enhanced createWorkspaceChat to accept and apply user-specified notebook options
- Updated documentation to include information about the new parameter

## Test plan
- Test creating workspace assistance with custom notebook options like WindowSize, WindowMargins, etc.
- Verify that options are properly merged with default options
- Confirm that documentation correctly describes the new parameter

🤖 Generated with [Claude Code](https://claude.ai/code)