### PR TITLE
Allow for line wrapping in NA input and output code blocks

### DIFF
--- a/DarkModeSupport/StyleSheets/Chatbook.nb
+++ b/DarkModeSupport/StyleSheets/Chatbook.nb
@@ -73,7 +73,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.23.3956653897"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935455"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],

--- a/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -87,7 +87,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.23.3956653897"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.28.3957935455"|>
   ],
   Cell[
    StyleData["AttachedCell"],
@@ -313,7 +313,15 @@ Notebook[
         {
          FrameBox[
           PaneBox[
-           #1,
+           PaneBox[
+            #1,
+            ImageSize ->
+             Dynamic[
+              If[#1 > 540, #1, 540] &[
+               0.95 * AbsoluteCurrentValue[{WindowSize, 1}]
+              ]
+             ]
+           ],
            AppearanceElements -> None,
            ImageSize -> {Scaled[1], UpTo[400]},
            Scrollbars -> Automatic

--- a/Developer/Resources/WorkspaceStyles.wl
+++ b/Developer/Resources/WorkspaceStyles.wl
@@ -259,9 +259,10 @@ Cell[
         GridBox[
             {
                 {
+                    (* Allow for some line breaking by setting a minimum window width *)
                     FrameBox[
                         PaneBox[
-                            #1,
+                            PaneBox[ #1, ImageSize -> Dynamic[ Function[ If[ # > 540, #, 540 ] ][ 0.95*AbsoluteCurrentValue[ { WindowSize, 1 } ] ] ] ],
                             AppearanceElements -> None,
                             ImageSize          -> { Scaled[ 1 ], UpTo[ 400 ] },
                             Scrollbars         -> Automatic

--- a/FrontEnd/Assets/Extensions/CoreExtensions.nb
+++ b/FrontEnd/Assets/Extensions/CoreExtensions.nb
@@ -11,7 +11,7 @@ Notebook[
   Cell["Chatbook Core.nb Extensions", "Title"],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.23.3956653897"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935455"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -824,7 +824,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.23.3956653702"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935366"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],

--- a/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -86,7 +86,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.23.3956653702"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.28.3957935366"|>
   ],
   Cell[
    StyleData["AttachedCell"],
@@ -285,7 +285,15 @@ Notebook[
         {
          FrameBox[
           PaneBox[
-           #1,
+           PaneBox[
+            #1,
+            ImageSize ->
+             Dynamic[
+              If[#1 > 540, #1, 540] &[
+               0.95 * AbsoluteCurrentValue[{WindowSize, 1}]
+              ]
+             ]
+           ],
            AppearanceElements -> None,
            ImageSize -> {Scaled[1], UpTo[400]},
            Scrollbars -> Automatic

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -1,7 +1,7 @@
 PacletObject[ <|
     "Name"           -> "Wolfram/Chatbook",
     "PublisherID"    -> "Wolfram",
-    "Version"        -> "2.3.27",
+    "Version"        -> "2.3.28",
     "WolframVersion" -> "14.1+",
     "Description"    -> "Wolfram Notebooks + LLMs",
     "License"        -> "MIT",

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -1929,7 +1929,7 @@ makeToolCallInputSection[ as: KeyValuePattern[ "Parameters" -> params_Associatio
         Grid[
             KeyValueMap[ { #1, formatter[ #2, "Parameters", #1 ] } &, params ],
             Alignment  -> Left,
-            BaseStyle  -> "Text",
+            BaseStyle  -> { "Text", LineBreakWithin -> Automatic },
             Dividers   -> All,
             FrameStyle -> color @ "NA_ChatOutputToolCallInputFrame",
             Spacings   -> 1
@@ -1987,10 +1987,11 @@ makeToolCallOutputSection[ as: KeyValuePattern[ "Result" -> result_ ] ] := Enclo
     Module[ { formatter },
         formatter = Confirm[ as[ "FormattingFunction" ], "FormattingFunction" ];
         TextCell[
-            wideScrollPane @ formatter[ result, "Result" ],
+            wideScrollPane @ ReplaceAll[ formatter[ result, "Result" ], Cell[ bd_BoxData, a___, "Input", b___ ] :> Cell[ bd, a, "Output", b ] ],
             "Text",
             Background      -> None,
             FrameBoxOptions -> { BaselinePosition -> Automatic },
+            LineBreakWithin -> Automatic,
             PaneBoxOptions  -> { BaselinePosition -> Automatic }
         ]
     ],
@@ -2004,8 +2005,9 @@ makeToolCallOutputSection // endDefinition;
 (*wideScrollPane*)
 wideScrollPane // beginDefinition;
 
+(* This definition is similar to WorkspaceStyles.wl: "ChatCodeBlockTemplate" but has a wider minimum because it has more room initially *)
 wideScrollPane[ expr_ ] := Pane[
-    expr,
+    Pane[ expr, ImageSize -> Dynamic[ Function[ If[ # > 600, #, 600 ] ][ 0.9*AbsoluteCurrentValue[ { WindowSize, 1 } ] ] ] ],
     ImageSize          -> { Scaled[ 1 ], UpTo[ 400 ] },
     Scrollbars         -> Automatic,
     AppearanceElements -> None


### PR DESCRIPTION
If a tool call occurs then the Input/Output code blocks within the tool call interface should line wrap at a reasonable width to promote easier reading.