### PR TITLE
Remove icons from models in the menus

### DIFF
--- a/Source/Chatbook/Menus.wl
+++ b/Source/Chatbook/Menus.wl
@@ -179,16 +179,16 @@ menuItemIcon // beginDefinition
 
 menuItemIcon[ spec_Association?AssociationQ ] :=
 If[ Lookup[ spec, "Check", None ] === None,
-    resizeMenuIcon @ Lookup[ spec, "Icon", Graphics[ Background -> Red ] ]
+    Lookup[ spec, "Icon", resizeMenuIcon @ Graphics[ Background -> Red ], Replace[ #, { None :> "", _ :> resizeMenuIcon @ # } ]& ]
     ,
-    Row[ {
+    Row[ Flatten @ {
         Switch[ Lookup[ spec, "Check", False ],
             True,      Style[ "\[Checkmark]", FontColor -> color @ "ChatMenuItemCheckmarkTrue" ],
             Inherited, Style[ "\[Checkmark]", FontColor -> color @ "ChatMenuItemCheckmarkInherited" ],
             _,         Style[ "\[Checkmark]", ShowContents -> False ]
         ],
-        " ",
-        resizeMenuIcon @ Lookup[ spec, "Icon", Graphics[ Background -> Red ] ] } ]
+        Lookup[ spec, "Icon", { " ", resizeMenuIcon @ Graphics[ Background -> Red ] }, Replace[ #, { None :> Nothing, _ :> { " ", resizeMenuIcon @ # } } ]& ]
+    } ]
 ]
 
 menuItemIcon // endDefinition

--- a/Source/Chatbook/UI.wl
+++ b/Source/Chatbook/UI.wl
@@ -1477,7 +1477,7 @@ modelMenuItem[
 ] := <|
 	"Type"   -> "Setter",
 	"Label"  -> displayName,
-	"Icon"   -> icon,
+	"Icon"   -> None,
 	"Check"  -> modelSelectionCheckmark[ currentModel, name ],
 	"Action" :> (setModel[ obj, model ])
 |>;


### PR DESCRIPTION
In the menus, the service providers display with an icon but the individual models do not need to.