### PR TITLE
Simplify StyleKeyMapping between chat-like cell styles

### DIFF
--- a/DarkModeSupport/StyleSheets/Chatbook.nb
+++ b/DarkModeSupport/StyleSheets/Chatbook.nb
@@ -73,7 +73,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935455"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.37.3959065236"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -153,9 +153,9 @@ Notebook[
    CellMargins -> {{66, 32}, {1, 8}},
    StyleKeyMapping -> {
     "~" -> "ChatDelimiter",
-    "'" -> "SideChat",
     "=" -> "WolframAlphaShort",
-    "*" -> "Item"
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
    },
    Evaluatable -> True,
    CellGroupingRules -> "InputGrouping",
@@ -384,11 +384,7 @@ Notebook[
     ],
    CellMargins -> {{79, 26}, {Inherited, Inherited}},
    CellDingbatMargin -> 0,
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatSystemInput",
-    "Backspace" -> "ChatInput"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"IncludeHistory" -> False|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameMargins -> {{0, Inherited}, {Inherited, Inherited}},
@@ -425,11 +421,7 @@ Notebook[
      BoxData[TemplateBox[{}, "ChatSystemIcon"]],
      Background -> None
     ],
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatInput",
-    "Backspace" -> "SideChat"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <||>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameStyle -> Dashing[{Small, Small}],
@@ -1068,7 +1060,13 @@ Notebook[
    StyleData["ChatDelimiter"],
    CellMargins -> {{5, 0}, {10, 10}},
    CellElementSpacings -> {"CellMinHeight" -> 6},
-   StyleKeyMapping -> {"~" -> "ChatBlockDivider", "'" -> "ChatInput"},
+   StyleKeyMapping -> {
+    "~" -> "ChatBlockDivider",
+    "'" -> "ChatInput",
+    "=" -> "WolframAlphaShort",
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
+   },
    CellGroupingRules -> {"SectionGrouping", 62},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"ChatDelimiter" -> True|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,

--- a/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -87,7 +87,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.28.3957935455"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.37.3959065236"|>
   ],
   Cell[
    StyleData["AttachedCell"],

--- a/Developer/Resources/Styles.wl
+++ b/Developer/Resources/Styles.wl
@@ -150,7 +150,7 @@ Cell[
     CounterIncrements     -> { "ChatInputCount" },
     Evaluatable           -> True,
     MenuSortingValue      -> 1543,
-    StyleKeyMapping       -> { "~" -> "ChatDelimiter", "'" -> "SideChat", "=" -> "WolframAlphaShort", "*" -> "Item" },
+    StyleKeyMapping       -> { "~" -> "ChatDelimiter", "=" -> "WolframAlphaShort", "*" -> "Item", ">" -> "ExternalLanguageDefault" },
     TaggingRules          -> <| "ChatNotebookSettings" -> <| |> |>,
     CellFrameLabels -> {
         {
@@ -265,7 +265,7 @@ Cell[
     CellFrameMargins  -> { { 0, Inherited }, { Inherited, Inherited } },
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
     CounterIncrements -> { },
-    StyleKeyMapping   -> { "~" -> "ChatDelimiter", "'" -> "ChatSystemInput", "Backspace" -> "ChatInput" },
+    StyleKeyMapping   -> { "~" -> "ChatDelimiter", "'" -> "ChatInput" },
     TaggingRules      -> <| "ChatNotebookSettings" -> <| "IncludeHistory" -> False |> |>,
     CellDingbat       -> Cell[
         BoxData @ RowBox @ {
@@ -312,7 +312,7 @@ Cell[
     CellTrayWidgets   -> <| "ChatWidget" -> <| "Visible" -> False |> |>,
     CounterIncrements -> { },
     MenuSortingValue  -> 1545,
-    StyleKeyMapping   -> { "~" -> "ChatDelimiter", "'" -> "ChatInput", "Backspace" -> "SideChat" },
+    StyleKeyMapping   -> { "~" -> "ChatDelimiter", "'" -> "ChatInput" },
     TaggingRules      -> <| "ChatNotebookSettings" -> <| |> |>
 ]
 
@@ -464,7 +464,7 @@ Cell[
     CounterAssignments  -> { { "ChatInputCount", 0 } },
     FontSize            -> 6,
     ShowCellLabel       -> False,
-    StyleKeyMapping     -> { "~" -> "ChatBlockDivider", "'" -> "ChatInput" },
+    StyleKeyMapping     -> { "~" -> "ChatBlockDivider", "'" -> "ChatInput", "=" -> "WolframAlphaShort", "*" -> "Item", ">" -> "ExternalLanguageDefault" },
     TaggingRules        -> <| "ChatNotebookSettings" -> <| "ChatDelimiter" -> True |> |>,
 
     CellEventActions -> {

--- a/FrontEnd/Assets/Extensions/CoreExtensions.nb
+++ b/FrontEnd/Assets/Extensions/CoreExtensions.nb
@@ -11,7 +11,7 @@ Notebook[
   Cell["Chatbook Core.nb Extensions", "Title"],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935455"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.37.3959065236"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -65,9 +65,9 @@ Notebook[
    CellMargins -> {{66, 32}, {1, 8}},
    StyleKeyMapping -> {
     "~" -> "ChatDelimiter",
-    "'" -> "SideChat",
     "=" -> "WolframAlphaShort",
-    "*" -> "Item"
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
    },
    Evaluatable -> True,
    CellGroupingRules -> "InputGrouping",
@@ -280,11 +280,7 @@ Notebook[
     ],
    CellMargins -> {{79, 26}, {Inherited, Inherited}},
    CellDingbatMargin -> 0,
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatSystemInput",
-    "Backspace" -> "ChatInput"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"IncludeHistory" -> False|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameMargins -> {{0, Inherited}, {Inherited, Inherited}},
@@ -321,11 +317,7 @@ Notebook[
      BoxData[TemplateBox[{}, "ChatSystemIcon"]],
      Background -> None
     ],
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatInput",
-    "Backspace" -> "SideChat"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <||>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameStyle -> Dashing[{Small, Small}],
@@ -964,7 +956,13 @@ Notebook[
    StyleData["ChatDelimiter"],
    CellMargins -> {{5, 0}, {10, 10}},
    CellElementSpacings -> {"CellMinHeight" -> 6},
-   StyleKeyMapping -> {"~" -> "ChatBlockDivider", "'" -> "ChatInput"},
+   StyleKeyMapping -> {
+    "~" -> "ChatBlockDivider",
+    "'" -> "ChatInput",
+    "=" -> "WolframAlphaShort",
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
+   },
    CellGroupingRules -> {"SectionGrouping", 62},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"ChatDelimiter" -> True|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,

--- a/FrontEnd/StyleSheets/Chatbook.nb
+++ b/FrontEnd/StyleSheets/Chatbook.nb
@@ -824,7 +824,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.3.28.3957935366"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.3.37.3959065193"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -900,9 +900,9 @@ Notebook[
    CellMargins -> {{66, 32}, {1, 8}},
    StyleKeyMapping -> {
     "~" -> "ChatDelimiter",
-    "'" -> "SideChat",
     "=" -> "WolframAlphaShort",
-    "*" -> "Item"
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
    },
    Evaluatable -> True,
    CellGroupingRules -> "InputGrouping",
@@ -1117,11 +1117,7 @@ Notebook[
     ],
    CellMargins -> {{79, 26}, {Inherited, Inherited}},
    CellDingbatMargin -> 0,
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatSystemInput",
-    "Backspace" -> "ChatInput"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"IncludeHistory" -> False|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameMargins -> {{0, Inherited}, {Inherited, Inherited}},
@@ -1154,11 +1150,7 @@ Notebook[
      BoxData[TemplateBox[{}, "ChatSystemIcon"]],
      Background -> None
     ],
-   StyleKeyMapping -> {
-    "~" -> "ChatDelimiter",
-    "'" -> "ChatInput",
-    "Backspace" -> "SideChat"
-   },
+   StyleKeyMapping -> {"~" -> "ChatDelimiter", "'" -> "ChatInput"},
    TaggingRules -> <|"ChatNotebookSettings" -> <||>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,
    CellFrameStyle -> Dashing[{Small, Small}],
@@ -1739,7 +1731,13 @@ Notebook[
    StyleData["ChatDelimiter"],
    CellMargins -> {{5, 0}, {10, 10}},
    CellElementSpacings -> {"CellMinHeight" -> 6},
-   StyleKeyMapping -> {"~" -> "ChatBlockDivider", "'" -> "ChatInput"},
+   StyleKeyMapping -> {
+    "~" -> "ChatBlockDivider",
+    "'" -> "ChatInput",
+    "=" -> "WolframAlphaShort",
+    "*" -> "Item",
+    ">" -> "ExternalLanguageDefault"
+   },
    CellGroupingRules -> {"SectionGrouping", 62},
    TaggingRules -> <|"ChatNotebookSettings" -> <|"ChatDelimiter" -> True|>|>,
    CellTrayWidgets -> <|"ChatWidget" -> <|"Visible" -> False|>|>,

--- a/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/FrontEnd/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -86,7 +86,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.28.3957935366"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.3.37.3959065193"|>
   ],
   Cell[
    StyleData["AttachedCell"],


### PR DESCRIPTION
Remove ChatSystemInput and SideChat styles from discovery via keyboard shortcuts.