### PR TITLE
Bugfix: Fixed an issue with incorrect inlined expression parsing

### DIFF
--- a/Source/Chatbook/CommonSymbols.wl
+++ b/Source/Chatbook/CommonSymbols.wl
@@ -1,5 +1,6 @@
 BeginPackage[ "Wolfram`Chatbook`Common`" ];
 
+`$$attachmentURI;
 `$absoluteCurrentSettingsCache;
 `$allowConnectionDialog;
 `$alwaysOpen;

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1158,8 +1158,7 @@ $llmAutoCorrectRules := $llmAutoCorrectRules = Flatten @ {
     "\\!\\("~~$$specialBoxName~~"[\"" ~~ Shortest[ uri__ ] ~~ "\"]\\)" :> uri,
     "\"\\\\!\\\\(\\\\*"~~$$specialBoxName~~"[\\\"" ~~ Shortest[ uri__ ] ~~ "\\\"]\\\\)\"" :> uri,
     "\"\\\\!\\\\("~~$$specialBoxName~~"[\\\"" ~~ Shortest[ uri__ ] ~~ "\\\"]\\\\)\"" :> uri,
-    "<" ~~ Shortest[ scheme: LetterCharacter.. ~~ "://" ~~ id: Except[ "!" ].. ] ~~ ">" :>
-        "<!" <> scheme <> "://" <> id <> "!>",
+    "<" ~~ uri: $$attachmentURI ~~ ">" :> "<!" <> uri <> "!>",
     "\\uf351" -> "\[FreeformPrompt]",
     "\\uF351" -> "\[FreeformPrompt]",
     "\:ff1d" -> "\[FreeformPrompt]",

--- a/Source/Chatbook/Tools/ExpressionURIs.wl
+++ b/Source/Chatbook/Tools/ExpressionURIs.wl
@@ -19,6 +19,8 @@ $$attachmentProperty = Alternatives @@ $attachmentTypes;
 
 $attachments = <| |>;
 
+$$attachmentURI := $$expressionScheme ~~ "://" ~~ $$expressionURIKey;
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*FormatToolResponse*)


### PR DESCRIPTION
# Before

![Screenshot 2025-07-01 125408](https://github.com/user-attachments/assets/c67f1a65-29fb-493a-affa-df65477eac77)

# After

![Screenshot 2025-07-01 125559](https://github.com/user-attachments/assets/b5e4d7ea-6cf0-4ab3-9da6-4a275aa264c6)

The original intention for this rule still works as expected:

![image](https://github.com/user-attachments/assets/f89e885f-974f-45b7-9d4e-d7d8e87b185d)