### PR TITLE
464549: double the length of allowed NA titles and add buffer length

### DIFF
--- a/Source/Chatbook/ChatTitle.wl
+++ b/Source/Chatbook/ChatTitle.wl
@@ -10,13 +10,13 @@ Needs[ "Wolfram`Chatbook`Common`" ];
 (* ::Section::Closed:: *)
 (*Configuration*)
 $maxTitleLength         = 30;
-$hardMaxTitleLength     = 40;
+$hardMaxTitleLength     = 100;
 $maxContextLength       = 100000; (* characters *)
 $multimodalTitleContext = False;
 
 $titlePrompt := "\
 Please come up with a meaningful window title for the current chat conversation using no more than \
-"<>ToString[$maxTitleLength]<>" characters.
+"<>ToString[$maxTitleLength-30]<>" characters.
 The title should be specific to the topics discussed in the chat.
 Do not give generic titles such as \"Chat\", \"Transcript\", or \"Chat Transcript\".
 Respond only with the title and nothing else.


### PR DESCRIPTION
Though we request a maximum title length from the LLM, it may hallucinate a longer title, so add some buffer as well.