### PR TITLE
Optimize Chat Title Generation

### DIFF
--- a/Source/Chatbook/ChatTitle.wl
+++ b/Source/Chatbook/ChatTitle.wl
@@ -10,19 +10,24 @@ Needs[ "Wolfram`Chatbook`Common`" ];
 (* ::Section::Closed:: *)
 (*Configuration*)
 $maxTitleLength         = 30;
-$hardMaxTitleLength     = 40;
+$hardMaxTitleLength     = 45;
 $maxContextLength       = 100000; (* characters *)
 $multimodalTitleContext = False;
+$tokenLengthMultiplier  = 3.0;
+$defaultEvaluator       = <| "Model" -> <| "Service" -> Automatic, "Name" -> "gpt-4.1-nano" |> |>;
 
 $titlePrompt := "\
 Please come up with a meaningful window title for the current chat conversation using no more than \
-"<>ToString[$maxTitleLength]<>" characters.
+`TargetLength` characters.
 The title should be specific to the topics discussed in the chat.
 Do not give generic titles such as \"Chat\", \"Transcript\", or \"Chat Transcript\".
+The title should contain only plain text, no markdown or other formatting.
 Respond only with the title and nothing else.
 
 Here is the chat transcript:
-`1`
+<transcript>
+`Transcript`
+</transcript>
 
 Remember, respond only with the title and nothing else.";
 
@@ -36,15 +41,19 @@ Remember, respond only with the title and nothing else.";
 (*GenerateChatTitle*)
 GenerateChatTitle // beginDefinition;
 GenerateChatTitle // Options = {
-    "Temperature" -> 0.7,
-    "MaxLength"   -> $maxTitleLength
+    "LLMEvaluator" -> $defaultEvaluator,
+    "MaxLength"    -> $hardMaxTitleLength,
+    "TargetLength" -> $maxTitleLength,
+    "Temperature"  -> 0.7
 };
 
 GenerateChatTitle[ messages: $$chatMessages, opts: OptionsPattern[ ] ] :=
     catchMine @ LogChatTiming @ generateChatTitle[
         messages,
-        OptionValue[ "Temperature" ],
-        OptionValue[ "MaxLength"   ]
+        OptionValue[ "LLMEvaluator" ],
+        OptionValue[ "Temperature"  ],
+        OptionValue[ "TargetLength" ],
+        OptionValue[ "MaxLength"    ]
     ];
 
 GenerateChatTitle // endExportedDefinition;
@@ -54,16 +63,18 @@ GenerateChatTitle // endExportedDefinition;
 (*generateChatTitle*)
 generateChatTitle // beginDefinition;
 
-generateChatTitle[ messages_, temperature_, maxLength_Integer? Positive ] :=
-    Block[ { $hardMaxTitleLength = maxLength },
-        generateChatTitle[ messages, temperature ]
-    ];
-
-generateChatTitle[ messages_, temperature_ ] := Enclose[
+generateChatTitle[ messages_, evaluator_, temperature_, targetLength_, maxLength_ ] := Enclose[
     Module[ { title, task },
 
         task = ConfirmMatch[
-            LogChatTiming @ generateChatTitleAsync[ messages, Function[ title = # ], temperature ],
+            LogChatTiming @ generateChatTitleAsync[
+                messages,
+                Function[ title = # ],
+                evaluator,
+                temperature,
+                targetLength,
+                maxLength
+            ],
             _TaskObject,
             "Task"
         ];
@@ -81,7 +92,23 @@ generateChatTitle // endDefinition;
 (* ::Section::Closed:: *)
 (*GenerateChatTitleAsynchronous*)
 GenerateChatTitleAsynchronous // beginDefinition;
-GenerateChatTitleAsynchronous[ messages: $$chatMessages, f_ ] := catchMine @ generateChatTitleAsync[ messages, f ];
+GenerateChatTitleAsynchronous // Options = {
+    "LLMEvaluator" -> $defaultEvaluator,
+    "MaxLength"    -> $hardMaxTitleLength,
+    "TargetLength" -> $maxTitleLength,
+    "Temperature"  -> 0.7
+};
+
+GenerateChatTitleAsynchronous[ messages: $$chatMessages, f_, opts: OptionsPattern[ ] ] :=
+    catchMine @ generateChatTitleAsync[
+        messages,
+        f,
+        OptionValue[ "LLMEvaluator" ],
+        OptionValue[ "Temperature"  ],
+        OptionValue[ "TargetLength" ],
+        OptionValue[ "MaxLength"    ]
+    ];
+
 GenerateChatTitleAsynchronous // endExportedDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -89,12 +116,30 @@ GenerateChatTitleAsynchronous // endExportedDefinition;
 (*generateChatTitleAsync*)
 generateChatTitleAsync // beginDefinition;
 
-generateChatTitleAsync[ messages: $$chatMessages, callback_, temperature: Automatic | _? NumericQ ] := Enclose[
+generateChatTitleAsync[
+    messages: $$chatMessages,
+    callback_,
+    evaluator_Association? AssociationQ,
+    temperature: Automatic | _? NumericQ,
+    targetLength_Integer? Positive,
+    maxLength_Integer? Positive
+] := Enclose[
     Module[ { string, short, instructions, context },
 
-        string       = ConfirmBy[ messagesToString[ messages, "IncludeSystemMessage" -> False ], StringQ, "String" ];
-        short        = ConfirmBy[ StringTake[ string, UpTo[ $maxContextLength ] ], StringQ, "Short" ];
-        instructions = ConfirmBy[ TemplateApply[ $titlePrompt, short ], StringQ, "Prompt" ];
+        string = ConfirmBy[ messagesToString[ messages, "IncludeSystemMessage" -> False ], StringQ, "String" ];
+        short  = ConfirmBy[ StringTake[ string, UpTo[ $maxContextLength ] ], StringQ, "Short" ];
+
+        instructions = ConfirmBy[
+            TemplateApply[
+                $titlePrompt,
+                <|
+                    "TargetLength" -> targetLength,
+                    "Transcript"   -> short
+                |>
+            ],
+            StringQ,
+            "Prompt"
+        ];
 
         context = ConfirmMatch[
             Block[ { $multimodalMessages = TrueQ @ $multimodalTitleContext },
@@ -108,7 +153,11 @@ generateChatTitleAsync[ messages: $$chatMessages, callback_, temperature: Automa
 
         ConfirmMatch[
             setServiceCaller[
-                llmSynthesizeSubmit[ context, <| "Temperature" -> temperature |>, callback @* postProcessChatTitle ],
+                llmSynthesizeSubmit[
+                    context,
+                    <| evaluator, "Temperature" -> temperature |>,
+                    callback @* postProcessChatTitle[ maxLength ]
+                ],
                 "GenerateChatTitle"
             ],
             _TaskObject,
@@ -125,8 +174,11 @@ generateChatTitleAsync // endDefinition;
 (*postProcessChatTitle*)
 postProcessChatTitle // beginDefinition;
 
-postProcessChatTitle[ title0_String, KeyValuePattern[ "StatusCode" -> 200 ] ] := Enclose[
-    Module[ { title, length },
+postProcessChatTitle[ maxLength_ ] :=
+    postProcessChatTitle[ maxLength, ## ] &;
+
+postProcessChatTitle[ maxLength_Integer? Positive, title0_String, KeyValuePattern[ "StatusCode" -> 200 ] ] := Enclose[
+    Module[ { title, clean, length },
 
         title = ConfirmBy[
             StringReplace[
@@ -139,46 +191,77 @@ postProcessChatTitle[ title0_String, KeyValuePattern[ "StatusCode" -> 200 ] ] :=
 
         ConfirmAssert[ StringQ @ title && StringLength @ title > 0, "StringCheck" ];
 
-        length = ConfirmBy[ titleLength @ title, NumberQ, "Length" ];
+        (* Remove the redundant substrings like " in Wolfram Language" from the generated title: *)
+        clean = ConfirmBy[ removeRedundantSubstrings @ title, StringQ, "Clean" ];
+
+        If[ StringLength @ clean < maxLength / 2, clean = title ];
+
+        length = ConfirmBy[ titleLength @ clean, NumberQ, "Length" ];
 
         Which[
-            StringContainsQ[ title, "\n"|"```" ],
+            StringContainsQ[ clean, "\n"|"```" ],
             Failure[
                 "TitleCharacters",
-                <| "MessageTemplate" -> "Unexpected characters in generated title.", "Title" -> title |>
+                <| "MessageTemplate" -> "Unexpected characters in generated title.", "Title" -> clean |>
             ],
 
-            length > $hardMaxTitleLength,
+            length > maxLength,
             Failure[
                 "TitleLength",
-                <| "MessageTemplate" -> "Generated title exceeds the maximum length.", "Title" -> title |>
+                <| "MessageTemplate" -> "Generated title exceeds the maximum length.", "Title" -> clean |>
             ],
 
             True,
-            title
+            clean
         ]
     ],
     throwInternalFailure
 ];
 
-postProcessChatTitle[ failure: Failure[ "InvalidResponse", _ ], _ ] :=
+postProcessChatTitle[ maxLength_, failure: Failure[ "InvalidResponse", _ ], _ ] :=
     throwTop @ failure;
 
-postProcessChatTitle[ failure: Failure[ "APIError", _ ], _ ] :=
+postProcessChatTitle[ maxLength_, failure: Failure[ "APIError", _ ], _ ] :=
     throwFailureToChatOutput @ failure;
 
 postProcessChatTitle // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
+(*removeRedundantSubstrings*)
+removeRedundantSubstrings // beginDefinition;
+
+removeRedundantSubstrings[ title_String ] := StringReplace[
+    title,
+    {
+        " "~~$$connector~~" "~~$$wolframLanguage~~EndOfString -> "",
+        StartOfString ~~ $$wolframLanguage ~~ " " ~~ c_? UpperCaseQ :> c
+    },
+    IgnoreCase -> True
+];
+
+removeRedundantSubstrings // endDefinition;
+
+$$connector = "in"|"with"|"using";
+$$wolframLanguage = Longest[ "Mathematica"|"Wolfram Language"|"Wolfram Lang"|"Wolfram"|"WL" ];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
 (*titleLength*)
-(* Checking the length of the title needs to be a mix of both string length and token counts because the LLM will
-   have an idea of the character length for some words, but for others it will not, in which case token counting
-   is more appropriate. This will avoid higher error probabilities for some titles that have particularly wide tokens,
-   e.g. " Histogram" is a single token. *)
+(* Measure title length using both character and token counts.
+   LLMs can estimate character counts for many words, but not reliably for all,
+   so token counts better handle unusually wide or single-token words.
+   Combining both reduces errors (e.g., " Histogram" is one token). *)
 titleLength // beginDefinition;
-titleLength[ title_String ] := StringLength @ title / 2.0 + Length @ cachedTokenizer[ "gpt-4o" ][ title ] * 1.5;
+titleLength[ title_String ] := (StringLength @ title + tokenLength @ title) / 2.0;
 titleLength // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*tokenLength*)
+tokenLength // beginDefinition;
+tokenLength[ title_String ] := Length @ cachedTokenizer[ "gpt-4o" ][ title ] * $tokenLengthMultiplier;
+tokenLength // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Storage.wl
+++ b/Source/Chatbook/Storage.wl
@@ -712,7 +712,7 @@ generateTitleCached0[ hash_Integer, messages_ ] :=
 
 generateTitleCached0[ hash_Integer, messages_ ] := Enclose[
     Catch @ Module[ { title },
-        title = ConfirmMatch[ GenerateChatTitle[ messages, "MaxLength" -> 40 ], _String|_Failure, "Title" ];
+        title = ConfirmMatch[ GenerateChatTitle[ messages, "MaxLength" -> 45 ], _String|_Failure, "Title" ];
 
         $lastGeneratedTitle = title;
         $lastRegeneratedTitle = None;
@@ -720,7 +720,7 @@ generateTitleCached0[ hash_Integer, messages_ ] := Enclose[
         (* retry once if first attempt failed using higher temperature and relaxed length constraint: *)
         If[ FailureQ @ title,
             title = ConfirmMatch[
-                GenerateChatTitle[ messages, "MaxLength" -> 50, "Temperature" -> 1.0 ],
+                GenerateChatTitle[ messages, "MaxLength" -> 60, "Temperature" -> 1.0 ],
                 _String|_Failure,
                 "Retry"
             ];


### PR DESCRIPTION
* Add options to `GenerateChatTitle` for easier testing and analysis
* Improve prompting so LLM more consistently follows instructions
* Switch title generation model to gpt-4.1-nano
* Add some string processing to remove redundant substrings from titles