### PR TITLE
Handle several evaluator tool edge cases

### DIFF
--- a/Assets/SandboxMessages.wl
+++ b/Assets/SandboxMessages.wl
@@ -1,4 +1,7 @@
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
 ExampleData::notent = "`1` is not a known entity for the collection `2`. Try using natural language input (\[FreeformPrompt][\"query\"]) to get the correct expression instead."
+General::quit = "The kernel quit unexpectedly during evaluation with exit code `1`."
 General::messages = "Messages were generated which may indicate errors. Use the documentation searcher tool to find solutions."
 General::usenl = "Messages involving `1` were generated. Try using natural language input (\[FreeformPrompt][\"query\"]) to get the correct expression instead."
 Needs::nocont = "Context `1` was not created when Needs was evaluated. Use the documentation searcher tool to find alternatives."
@@ -7,3 +10,4 @@ RandomEntity::ntype = "`1` is not a valid type of Entity or EntityClass. Use the
 ResourceObject::notfname = "The ResourceObject `1` does not exist. Use the documentation searcher tool to find alternatives."
 Symbol::undefined = "Warning: Global symbol `1` is undefined. Use the documentation searcher tool to find alternatives."
 Symbol::undefined2 = "Warning: Global symbols `1` are undefined. Use the documentation searcher tool to find alternatives."
+(* :!CodeAnalysis::EndBlock:: *)

--- a/Scripts/Common.wl
+++ b/Scripts/Common.wl
@@ -47,7 +47,7 @@ $testingHeads = HoldPattern @ Alternatives[
 ];
 (* :!CodeAnalysis::EndBlock:: *)
 
-$testStack = With[ { h = $testingHeads }, HoldForm[ h[ ___ ] ] ];
+$testStack = With[ { h = $testingHeads }, (HoldForm|System`HoldCompleteForm)[ h[ ___ ] ] ];
 
 messageHandler[
     Hold @ Message[ Wolfram`PacletCICD`TestPaclet::Failures, ___ ],

--- a/Scripts/Resources/CodeInspectorRules.wl
+++ b/Scripts/Resources/CodeInspectorRules.wl
@@ -53,8 +53,10 @@ scanSingleArgThrow[ pos_, ast_ ] := Catch[
 (*walkASTForCatch*)
 walkASTForCatch // ClearAll;
 
-walkASTForCatch[ cp`CallNode[ cp`LeafNode[ Symbol, "Catch"|"Hold"|"HoldForm"|"HoldComplete", _ ], { _ }, _ ], _ ] :=
-    Throw[ { }, $tag ];
+walkASTForCatch[
+    cp`CallNode[ cp`LeafNode[ Symbol, "Catch"|"Hold"|"HoldForm"|"HoldComplete"|"HoldCompleteForm", _ ], { _ }, _ ],
+    _
+] := Throw[ { }, $tag ];
 
 walkASTForCatch[ ast_, pos_ ] :=
     Extract[ ast, pos ];

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -3,6 +3,8 @@
 (*Package Header*)
 BeginPackage[ "Wolfram`Chatbook`Common`" ];
 
+System`HoldCompleteForm;
+
 (* :!CodeAnalysis::BeginBlock:: *)
 
 (* ::**************************************************************************************************************:: *)
@@ -1078,7 +1080,7 @@ $bugReportStack := StringRiffle[
     Reverse @ Replace[
         DeleteAdjacentDuplicates @ Cases[
             Stack[ _ ],
-            HoldForm[ (s_Symbol) | (s_Symbol)[ ___ ] | (s_Symbol)[ ___ ][ ___ ] ] /;
+            (HoldForm|HoldCompleteForm)[ (s_Symbol) | (s_Symbol)[ ___ ] | (s_Symbol)[ ___ ][ ___ ] ] /;
                 AtomQ @ Unevaluated @ s && StringStartsQ[ Context @ s, "Wolfram`Chatbook`" ] :>
                     SymbolName @ Unevaluated @ s
         ],

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -29,6 +29,7 @@ $cloudSession              = None;
 $maxSandboxMessages        = 10;
 $maxMessageParameterLength = 100;
 $toolOutputPageWidth       = 100;
+$kernelQuit                = False;
 
 (* Tests for expressions that lose their initialized status when sending over a link: *)
 $initializationTests = Join[
@@ -619,14 +620,19 @@ $messageOverrides := $messageOverrides = Flatten @ Apply[
 (* ::Subsection::Closed:: *)
 (*sandboxEvaluate*)
 sandboxEvaluate // beginDefinition;
+sandboxEvaluate[ eval_ ] := Block[ { $kernelQuit = False }, sandboxEvaluate0 @ eval ];
+sandboxEvaluate // endDefinition;
 
-sandboxEvaluate[ KeyValuePattern[ "code" -> code_ ] ] := sandboxEvaluate @ code;
-sandboxEvaluate[ code_String ] := sandboxEvaluate @ toSandboxExpression @ code // LogChatTiming[ "SandboxEvaluate" ];
-sandboxEvaluate[ HoldComplete[ xs__, x_ ] ] := sandboxEvaluate @ HoldComplete @ CompoundExpression[ xs, x ];
-sandboxEvaluate[ HoldComplete[ eval_ ] ] /; useCloudSandboxQ[ ] := cloudSandboxEvaluate @ HoldComplete @ eval;
-sandboxEvaluate[ HoldComplete[ eval_ ] ] /; useSessionQ[ ] := sessionEvaluate @ HoldComplete @ eval;
 
-sandboxEvaluate[ HoldComplete[ evaluation_ ] ] := Enclose[
+sandboxEvaluate0 // beginDefinition;
+
+sandboxEvaluate0[ KeyValuePattern[ "code" -> code_ ] ] := sandboxEvaluate0 @ code;
+sandboxEvaluate0[ code_String ] := sandboxEvaluate0 @ toSandboxExpression @ code // LogChatTiming[ "SandboxEvaluate" ];
+sandboxEvaluate0[ HoldComplete[ xs__, x_ ] ] := sandboxEvaluate0 @ HoldComplete @ CompoundExpression[ xs, x ];
+sandboxEvaluate0[ HoldComplete[ eval_ ] ] /; useCloudSandboxQ[ ] := cloudSandboxEvaluate @ HoldComplete @ eval;
+sandboxEvaluate0[ HoldComplete[ eval_ ] ] /; useSessionQ[ ] := sessionEvaluate @ HoldComplete @ eval;
+
+sandboxEvaluate0[ HoldComplete[ evaluation_ ] ] := Enclose[
     Module[ { kernel, null, packets, $sandboxTag, $timedOut, $kernelQuit, results, flat, initialized, final },
 
         $lastSandboxMethod = "Local";
@@ -701,7 +707,7 @@ sandboxEvaluate[ HoldComplete[ evaluation_ ] ] := Enclose[
     throwInternalFailure
 ];
 
-sandboxEvaluate // endDefinition;
+sandboxEvaluate0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -1131,7 +1137,10 @@ expandSandboxMacros[ expr_HoldComplete ] := Enclose[
         };
 
         With[ { messages = Internal`BagPart[ msgBag, All ] },
-            Replace[ expanded, HoldComplete[ e___ ] :> HoldComplete[ Scan[ Print, messages ]; StackBegin @ e ] ]
+            Replace[
+                expanded,
+                HoldComplete[ e___ ] :> HoldComplete[ Scan[ Print, messages ]; StackBegin @ Unevaluated @ e ]
+            ]
         ]
     ],
     throwInternalFailure
@@ -1401,19 +1410,22 @@ evaluationData // endDefinition;
 setOutput // beginDefinition;
 setOutput // Attributes = { SequenceHold };
 
-setOutput[ HoldComplete[ KeyValuePattern[ "Result" -> HoldComplete[ result_ ] ] ] ] :=
+setOutput[ HoldComplete[ KeyValuePattern[ "Result" -> HoldComplete[ result___ ] ] ] ] :=
     setOutput[ Replace[ $Line, Except[ _Integer ] :> 1 ], HoldComplete @ result ];
 
 setOutput[ HoldComplete[ fail_Failure ] ] :=
     setOutput[ Replace[ $Line, Except[ _Integer ] :> 1 ], HoldComplete @ fail ];
 
-setOutput[ line_Integer, HoldComplete[ result___ ] ] :=
+setOutput[ line_Integer, HoldComplete[ result_ ] ] :=
     WithCleanup[
         Unprotect @ Out,
         Out[ line ] := result,
         Protect @ Out;
         $Line = line + 1
     ];
+
+setOutput[ line_Integer, HoldComplete[ result___ ] ] :=
+    setOutput[ line, HoldComplete @ Sequence @ result ];
 
 setOutput // endDefinition;
 
@@ -1464,7 +1476,11 @@ evaluationMessageHandler0[ stopped_, outputs_, Hold[ Message[ mn_, ___ ], _ ] ] 
 evaluationMessageHandler0[ _, _, Hold[ message_? messageQuietedQ, _ ] ] := Null;
 
 (* Message has triggered a `General::stop`, but it's locally quiet, so mark it and otherwise do nothing: *)
-evaluationMessageHandler0[ stopped_, _, Hold[ Message[ General::stop, HoldForm[ msg_? messageQuietedQ ] ], _ ] ] := (
+evaluationMessageHandler0[
+    stopped_,
+    _,
+    Hold[ Message[ General::stop, (HoldForm|HoldCompleteForm)[ msg_? messageQuietedQ ] ], _ ]
+] := (
     stopped[ HoldComplete @ msg ] = True;
     Null
 );
@@ -1491,8 +1507,12 @@ evaluationMessageHandler0 // endDefinition;
 (*checkMessageStop*)
 checkMessageStop // beginDefinition;
 checkMessageStop // Attributes = { HoldAllComplete };
-checkMessageStop[ stopped_, Message[ General::stop, HoldForm[ stop_ ] ] ] := stopped[ HoldComplete @ stop ] = True;
+
+checkMessageStop[ stopped_, Message[ General::stop, (HoldForm|HoldCompleteForm)[ stop_ ] ] ] :=
+    stopped[ HoldComplete @ stop ] = True;
+
 checkMessageStop[ stopped_, _Message ] := Null;
+
 checkMessageStop // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -1505,7 +1525,7 @@ makeMessageText[ Message[ mn: MessageName[ sym_Symbol, tag__String ], args0___ ]
     Module[ { template, label, args },
         template = SelectFirst[ { messageOverrideTemplate @ mn, mn, MessageName[ General, tag ] }, StringQ ];
         label    = ToString @ Unevaluated @ mn;
-        args     = HoldForm /@ Unevaluated @ { args0 };
+        args     = HoldCompleteForm /@ Unevaluated @ { args0 };
         If[ StringQ @ template,
             applyMessageTemplate[ label, template, args ],
             undefinedMessageText[ label, args ]
@@ -1562,7 +1582,7 @@ countLargeParameters // endDefinition;
 largeParameterQ // beginDefinition;
 largeParameterQ[ _String ] := True;
 largeParameterQ[ $$atomic ] := False;
-largeParameterQ[ HoldForm[ expr_ ] ] := largeParameterQ @ expr;
+largeParameterQ[ (HoldForm|HoldCompleteForm)[ expr_ ] ] := largeParameterQ @ expr;
 largeParameterQ[ _ ] := True;
 largeParameterQ // Attributes = { HoldAllComplete };
 largeParameterQ // endDefinition;
@@ -1649,9 +1669,15 @@ inheritingOffQ // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*localStack*)
 localStack // beginDefinition;
-localStack[ HoldForm @ { ___, { ___, { $stackTag::begin }, ___ }, stack___ } ] := localStack @ HoldForm @ { stack };
-localStack[ HoldForm @ { stack___, { ___, { $stackTag::end }, ___ }, ___ } ] := localStack @ HoldForm @ { stack };
+
+localStack[ (HoldForm|HoldCompleteForm) @ { ___, { ___, { $stackTag::begin }, ___ }, stack___ } ] :=
+    localStack @ HoldCompleteForm @ { stack };
+
+localStack[ (HoldForm|HoldCompleteForm) @ { stack___, { ___, { $stackTag::end }, ___ }, ___ } ] :=
+    localStack @ HoldCompleteForm @ { stack };
+
 localStack[ stack_ ] := stack;
+
 localStack // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -1673,7 +1699,22 @@ generalMessagePattern // endDefinition;
 (*catchEverything*)
 catchEverything // beginDefinition;
 catchEverything // Attributes = { HoldAllComplete };
-catchEverything[ e_ ] := catchEverything0 @ CheckAbort[ Catch @ Catch[ contained @ e, _, uncaughtThrow ], $Aborted ];
+
+catchEverything[ e_ ] :=
+    Internal`InheritedBlock[ { Catch, Throw },
+        Catch[
+            Unprotect[ Catch, Throw ];
+            PrependTo[ DownValues @ Catch, HoldPattern @ Catch[ expr_ ] :> Catch[ expr, $untagged ] ];
+            PrependTo[ DownValues @ Throw, HoldPattern @ Throw[ expr_ ] :> Throw[ expr, $untagged ] ];
+            Protect[ Catch, Throw ]
+        ];
+        catchEverything0 @ CheckAbort[
+            Catch[ handleKernelQuit @ contained @ e, _, uncaughtThrow ],
+            $Aborted,
+            PropagateAborts -> False
+        ]
+    ];
+
 catchEverything // endDefinition;
 
 
@@ -1686,8 +1727,19 @@ catchEverything0[ contained[ result___ ] ] :=
 catchEverything0[ $Aborted ] :=
     makeHeldResultAssociation @ $Aborted;
 
+catchEverything0[ uncaughtThrow[ uncaught_, $untagged ] ] := (
+    Message[ Throw::nocatch, HoldCompleteForm @ Throw @ uncaught ];
+    makeHeldResultAssociation @ Hold @ Throw @ uncaught
+);
+
+catchEverything0[ uncaughtThrow[ code_Integer, $kernelExitTag ] ] := (
+    $kernelQuit = True;
+    Message[ General::quit, code ];
+    makeHeldResultAssociation @ kernelExit @ code
+);
+
 catchEverything0[ uncaughtThrow[ uncaught__ ] ] := (
-    Message[ Throw::nocatch, HoldForm @ Throw @ uncaught ];
+    Message[ Throw::nocatch, HoldCompleteForm @ Throw @ uncaught ];
     makeHeldResultAssociation @ Hold @ Throw @ uncaught
 );
 
@@ -1704,6 +1756,72 @@ catchEverything0 // endDefinition;
 
 contained // Attributes = { SequenceHold };
 uncaughtThrow // Attributes = { HoldAllComplete };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*handleKernelQuit*)
+handleKernelQuit // beginDefinition;
+handleKernelQuit // Attributes = { HoldAllComplete };
+handleKernelQuit[ eval_ ] := handleQuit @ handleExit @ eval;
+handleKernelQuit // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*handleExit*)
+handleExit // beginDefinition;
+handleExit // Attributes = { HoldAllComplete };
+
+handleExit[ eval_ ] := Internal`InheritedBlock[ { Exit },
+    Unprotect @ Exit;
+    PrependTo[ DownValues @ Exit, HoldPattern @ Exit[ code_Integer ] :> Throw[ code, $kernelExitTag ] ];
+    PrependTo[ DownValues @ Exit, HoldPattern @ Exit[ ] :> Throw[ 0, $kernelExitTag ] ];
+    Protect @ Exit;
+    eval
+];
+
+handleExit // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*handleQuit*)
+handleQuit // beginDefinition;
+handleQuit // Attributes = { HoldAllComplete };
+
+(* Quit is locked in cloud, so we can't use a Block to redefine it.
+   Instead, we'll replace literal occurrences of Quit with our own override. *)
+handleQuit[ eval_ ] /; $CloudEvaluation :=
+    Module[ { held, released },
+
+        held = ReplaceAll[
+            HoldComplete @ eval,
+            {
+                HoldPattern @ Quit[ ] :> quitOverride[ ],
+                HoldPattern @ Quit[ code_Integer ] :> quitOverride @ code
+            }
+        ];
+
+        released = ReleaseHold @ held;
+
+        released /. quitOverride -> Quit
+    ];
+
+handleQuit[ eval_ ] := Internal`InheritedBlock[ { Quit },
+    Unprotect @ Quit;
+    PrependTo[ DownValues @ Quit, HoldPattern @ Quit[ ] :> Throw[ 0, $kernelExitTag ] ];
+    PrependTo[ DownValues @ Quit, HoldPattern @ Quit[ code_Integer ] :> Throw[ code, $kernelExitTag ] ];
+    Protect @ Quit;
+    eval
+];
+
+handleQuit // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*quitOverride*)
+quitOverride // beginDefinition;
+quitOverride[ ] := Throw[ 0, $kernelExitTag ];
+quitOverride[ code_Integer ] := Throw[ code, $kernelExitTag ];
+quitOverride // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -1814,7 +1932,10 @@ addInitializations // beginDefinition;
 addInitializations[ eval_HoldComplete ] := addInitializations[ eval, $initializationTest ];
 
 addInitializations[ HoldComplete[ eval_ ], initializedQ_ ] :=
-    HoldComplete @ With[ { result = HoldComplete @@ { eval } },
+    HoldComplete @ With[
+        {
+            result = Replace[ HoldComplete @@ { eval }, HoldComplete[ ] :> HoldComplete @ Sequence[ ] ]
+        },
         <|
             "Line"        -> $Line,
             "Result"      -> result,
@@ -1827,7 +1948,7 @@ addInitializations // endDefinition;
 
 $initializationTest := $initializationTest = Module[ { tests, slot, func },
     tests = Flatten[ HoldComplete @@ Cases[ $initializationTests, f_ :> HoldComplete @ f @ slot[ 1 ] ] ];
-    func = Replace[ tests, HoldComplete[ t___ ] :> Function[ Null, TrueQ @ Or @ t, HoldAllComplete ] ];
+    func = Replace[ tests, HoldComplete[ t___ ] :> Function[ Null, Quiet @ TrueQ @ Or @ t, HoldAllComplete ] ];
     func /. slot -> Slot
 ];
 
@@ -1883,7 +2004,7 @@ createEvaluationWithWarnings // Attributes = { HoldAllComplete };
 
 createEvaluationWithWarnings[ evaluation_ ] :=
     Module[ { held, undefined },
-        held = Flatten @ HoldComplete @ StackBegin @ evaluation;
+        held = Flatten @ HoldComplete @ StackBegin @ Unevaluated @ evaluation;
 
         undefined = Flatten[ HoldComplete @@ Cases[
             Unevaluated @ evaluation,
@@ -1970,8 +2091,9 @@ undefinedSymbolQ[ ___ ] := False;
 sandboxResult // beginDefinition;
 sandboxResult[ HoldComplete @ Association @ OrderlessPatternSequence[ "Result" -> res_, ___ ] ] := sandboxResult @ res;
 sandboxResult[ HoldComplete[ held_HoldComplete ] ] := sandboxResult @ held;
-sandboxResult[ HoldComplete[ ___, expr_ ] ] := HoldForm @ expr;
-sandboxResult[ res_ ] := HoldForm @ res;
+sandboxResult[ HoldComplete[ ___, kernelExit[ code_Integer ] ] ] := Failure[ "KernelQuit", <| "ExitCode" -> code |> ];
+sandboxResult[ HoldComplete[ ___, expr_ ] ] := HoldCompleteForm @ expr;
+sandboxResult[ res_ ] := HoldCompleteForm @ res;
 sandboxResult // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -1997,7 +2119,10 @@ sandboxResultString0[ HoldComplete[ KeyValuePattern @ { "Line" -> line_, "Result
         StringTrim @ StringRiffle[
             Flatten @ {
                 makePacketMessages[ ToString @ line, packets ],
-                "\nOut[" <> ToString @ line <> "]= " <> sandboxResultString0 @ Flatten @ HoldComplete @ result
+                If[ MatchQ[ Unevaluated @ result, HoldComplete[ _kernelExit ] ],
+                    "",
+                    "\nOut[" <> ToString @ line <> "]= " <> sandboxResultString0 @ Flatten @ HoldComplete @ result
+                ]
             },
             "\n"
         ],
@@ -2044,12 +2169,20 @@ preprocessForResultString // beginDefinition;
 preprocessForResultString[ expr_ ] := ReplaceAll[
     expr,
     {
-        gfx_? graphicsQ :>
+        gfx_? safeGraphicsQ :>
             RuleCondition @ markdownExpression @ MakeExpressionURI[ ToString @ Head @ Unevaluated @ gfx, gfx ]
     }
 ];
 
 preprocessForResultString // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*safeGraphicsQ*)
+safeGraphicsQ // beginDefinition;
+safeGraphicsQ // Attributes = { HoldAllComplete };
+safeGraphicsQ[ e_ ] := graphicsQ @ Unevaluated @ e;
+safeGraphicsQ // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)
@@ -2118,12 +2251,16 @@ appendURIInstructions[ string_String, HoldComplete[ ___, expr_ ] ] := Enclose[
     throwInternalFailure
 ];
 
+appendURIInstructions[ string_String, HoldComplete[ ] ] :=
+    appendURIInstructions[ string, HoldComplete @ Sequence[ ] ];
+
 appendURIInstructions // endDefinition;
 
 
 appendURIInstructions0 // beginDefinition;
 
-appendURIInstructions0[ string_String, HoldForm[ expr_ ] ] := appendURIInstructions0[ string, HoldComplete @ expr ];
+appendURIInstructions0[ string_String, (HoldForm|HoldCompleteForm)[ expr_ ] ] :=
+    appendURIInstructions0[ string, HoldComplete @ expr ];
 
 appendURIInstructions0[ string_String, HoldComplete[ ___, expr_? appendURIQ ] ] := Enclose[
     Module[ { uri, key, message },
@@ -2246,7 +2383,7 @@ makePacketMessages[ line_, packets_List ] := Enclose[
     Module[ { strings },
         $appendGeneralMessage = False;
         strings = ConfirmMatch[ makePacketMessage /@ packets, { ___String }, "Strings" ];
-        If[ ConfirmBy[ $appendGeneralMessage, BooleanQ, "AppendGeneralMessage" ],
+        If[ ConfirmBy[ $appendGeneralMessage && ! $kernelQuit, BooleanQ, "AppendGeneralMessage" ],
             Append[ strings, ConfirmBy[ $generalMessageText, StringQ, "GeneralMessage" ] ],
             strings
         ]

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -721,9 +721,13 @@ cellToString[ Cell[ a__, "Message"|"MSG", b___ ] ] :=
     Module[ { string, stacks, stack, stackString },
         { string, stacks } = Reap[ cellToString0 @ Cell[ a, b ], $messageStack ];
         stack = First[ First[ stacks, $Failed ], $Failed ];
-        If[ MatchQ[ stack, { __HoldForm } ] && Length @ stack >= 3
+        If[ MatchQ[ stack, { (_HoldForm|_HoldCompleteForm).. } ] && Length @ stack >= 3
             ,
-            stackString = StringRiffle[ Cases[ stack, HoldForm[ expr_ ] :> stackFrameString @ expr ], "\n" ];
+            stackString = StringRiffle[
+                Cases[ stack, (HoldForm|HoldCompleteForm)[ expr_ ] :> stackFrameString @ expr ],
+                "\n"
+            ];
+
             needsBasePrompt[ "MessageStackTrace" ];
             TemplateApply[
                 $stackTraceTemplate,
@@ -3353,7 +3357,7 @@ makeGraphicsExpression[ gfx_ ] := Quiet @ Check[ ToExpression[ gfx, StandardForm
 (*sowMessageData*)
 sowMessageData[ { _, _, _, _, line_Integer, counter_Integer, session_Integer, __ } ] /; $includeStackTrace :=
     With[ { stack = MessageMenu`MessageStackList[ line, counter, session ] },
-        Sow[ stack, $messageStack ] /; MatchQ[ stack, { __HoldForm } ]
+        Sow[ stack, $messageStack ] /; MatchQ[ stack, { (_HoldForm|_HoldCompleteForm).. } ]
     ];
 
 sowMessageData[ ___ ] := Null;

--- a/Tests/WolframLanguageToolEvaluate.wlt
+++ b/Tests/WolframLanguageToolEvaluate.wlt
@@ -45,21 +45,21 @@ VerificationTest[
 
 VerificationTest[
     WolframLanguageToolEvaluate[ "1 + 1", "Result", Method -> "Session" ],
-    HoldForm[ 2 ],
+    HoldCompleteForm[ 2 ],
     SameTest -> MatchQ,
     TestID   -> "ResultProperty@@Tests/WolframLanguageToolEvaluate.wlt:46,1-51,2"
 ]
 
 VerificationTest[
     WolframLanguageToolEvaluate[ "1 + 1", { "Result", "String" }, Method -> "Session" ],
-    KeyValuePattern @ { "Result" -> HoldForm[ 2 ], "String" -> _String },
+    KeyValuePattern @ { "Result" -> HoldCompleteForm[ 2 ], "String" -> _String },
     SameTest -> MatchQ,
     TestID   -> "MultipleProperties@@Tests/WolframLanguageToolEvaluate.wlt:53,1-58,2"
 ]
 
 VerificationTest[
     WolframLanguageToolEvaluate[ "1 + 1", All, Method -> "Session" ],
-    KeyValuePattern @ { "Result" -> HoldForm[ 2 ], "String" -> _String },
+    KeyValuePattern @ { "Result" -> HoldCompleteForm[ 2 ], "String" -> _String },
     SameTest -> MatchQ,
     TestID   -> "AllProperties@@Tests/WolframLanguageToolEvaluate.wlt:60,1-65,2"
 ]
@@ -123,7 +123,7 @@ VerificationTest[
 (*Multimodal Input*)
 VerificationTest[
     WolframLanguageToolEvaluate[ { "ImageDimensions[", RandomImage[ ], "]" }, "Result", Method -> "Session" ],
-    HoldForm @ { _Integer, _Integer },
+    HoldCompleteForm @ { _Integer, _Integer },
     SameTest -> MatchQ,
     TestID   -> "MultimodalInput-1@@Tests/WolframLanguageToolEvaluate.wlt:124,1-129,2"
 ]
@@ -133,14 +133,134 @@ VerificationTest[
 (*Auto-Correcting Input*)
 VerificationTest[
     WolframLanguageToolEvaluate[ "Dimensions[{{1,2},{3,4},{5,6}}", "Result", Method -> "Session" ],
-    HoldForm @ { 3, 2 },
+    HoldCompleteForm @ { 3, 2 },
     SameTest -> MatchQ,
     TestID   -> "AutoCorrectingInput-1@@Tests/WolframLanguageToolEvaluate.wlt:134,1-139,2"
 ]
 
 VerificationTest[
     WolframLanguageToolEvaluate[ { "ImageDimensions[", RandomImage[ ] }, "Result", Method -> "Session" ],
-    HoldForm @ { _Integer, _Integer },
+    HoldCompleteForm @ { _Integer, _Integer },
     SameTest -> MatchQ,
     TestID   -> "AutoCorrectingInput-2@@Tests/WolframLanguageToolEvaluate.wlt:141,1-146,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Edge Cases*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Empty Sequence*)
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Sequence[]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "Out[1]= Sequence[]",
+        "Result" -> HoldCompleteForm @ Sequence[ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-SequenceInput@@Tests/WolframLanguageToolEvaluate.wlt:155,1-163,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Sneaky Throw*)
+VerificationTest[
+    as = WolframLanguageToolEvaluate[ "Throw[Unevaluated[Throw[Null]]]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> _String,
+        "Result" -> HoldCompleteForm @ Hold @ Throw @ Null
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-UncaughtThrow@@Tests/WolframLanguageToolEvaluate.wlt:168,1-176,2"
+]
+
+VerificationTest[
+    StringContainsQ[ as[ "String" ], "Throw::nocatch: Uncaught Throw[Null] returned to top level." ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-UncaughtThrow-Message@@Tests/WolframLanguageToolEvaluate.wlt:178,1-183,2"
+]
+
+VerificationTest[
+    StringContainsQ[ as[ "String" ], "Out[1]= Hold[Throw[Null]]" ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-UncaughtThrow-Output@@Tests/WolframLanguageToolEvaluate.wlt:185,1-190,2"
+]
+
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Throw[Unevaluated[Throw[Null]], \"tag\"]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> _String,
+        "Result" -> HoldCompleteForm @ Hold @ Throw[ Throw @ Null, "tag" ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-UncaughtThrow-Tagged@@Tests/WolframLanguageToolEvaluate.wlt:192,1-200,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Abort*)
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Abort[]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "Out[1]= $Aborted",
+        "Result" -> HoldCompleteForm @ $Aborted
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-Abort@@Tests/WolframLanguageToolEvaluate.wlt:205,1-213,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Kernel Quit*)
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Exit[]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "General::quit: The kernel quit unexpectedly during evaluation with exit code 0.",
+        "Result" -> Failure[ "KernelQuit", _ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-KernelQuit-Exit-Null@@Tests/WolframLanguageToolEvaluate.wlt:218,1-226,2"
+]
+
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Exit[1]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "General::quit: The kernel quit unexpectedly during evaluation with exit code 1.",
+        "Result" -> Failure[ "KernelQuit", _ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-KernelQuit-Exit-1@@Tests/WolframLanguageToolEvaluate.wlt:228,1-236,2"
+]
+
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Quit[]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "General::quit: The kernel quit unexpectedly during evaluation with exit code 0.",
+        "Result" -> Failure[ "KernelQuit", _ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-KernelQuit-Quit-Null@@Tests/WolframLanguageToolEvaluate.wlt:238,1-246,2"
+]
+
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Quit[1]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "General::quit: The kernel quit unexpectedly during evaluation with exit code 1.",
+        "Result" -> Failure[ "KernelQuit", _ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-KernelQuit-Quit-1@@Tests/WolframLanguageToolEvaluate.wlt:248,1-256,2"
+]
+
+VerificationTest[
+    WolframLanguageToolEvaluate[ "Exit[1]; Print[\"Hello\"]; Quit[2]", All, Method -> "Session", Line -> 1 ],
+    KeyValuePattern @ {
+        "String" -> "General::quit: The kernel quit unexpectedly during evaluation with exit code 1.",
+        "Result" -> Failure[ "KernelQuit", _ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "EdgeCases-KernelQuit-Exit-Stop@@Tests/WolframLanguageToolEvaluate.wlt:258,1-266,2"
 ]


### PR DESCRIPTION
* Update pattern matching to handle `HoldCompleteForm` changes in 15.0
* Intercept programmatic kernel quits in evaluator code
* Fixed possible uncaught throws in evaluator code
* Handle `Sequence[]` outputs