### PR TITLE
Simplify code block template: no auto line-breaking

### DIFF
--- a/DarkModeSupport/StyleSheets/Chatbook.nb
+++ b/DarkModeSupport/StyleSheets/Chatbook.nb
@@ -73,7 +73,7 @@ Notebook[
   ],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.5.56.3980325675"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.5.68.3981191117"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],

--- a/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
+++ b/DarkModeSupport/StyleSheets/Wolfram/WorkspaceChat.nb
@@ -87,7 +87,7 @@ Notebook[
   Cell[StyleData["CellExpression"], Selectable -> True],
   Cell[
    StyleData["WorkspaceChatStyleSheetInformation"],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.5.56.3980325675"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.5.68.3981191117"|>
   ],
   Cell[
    StyleData["AttachedCell"],
@@ -313,16 +313,9 @@ Notebook[
         {
          FrameBox[
           PaneBox[
-           PaneBox[
-            #1,
-            ImageSize ->
-             Dynamic[
-              If[#1 > 540, #1, 540] &[
-               0.95 * AbsoluteCurrentValue[{WindowSize, 1}]
-              ]
-             ]
-           ],
+           #1,
            AppearanceElements -> None,
+           BaseStyle -> {LineBreakWithin -> False},
            ImageSize -> {Scaled[1], UpTo[400]},
            Scrollbars -> Automatic
           ],

--- a/Developer/Resources/WorkspaceStyles.wl
+++ b/Developer/Resources/WorkspaceStyles.wl
@@ -259,11 +259,12 @@ Cell[
         GridBox[
             {
                 {
-                    (* Allow for some line breaking by setting a minimum window width *)
+                    (* Don't line break: assume the LLM returns code that is compact, and rely on automatic scrollbars otherwise *)
                     FrameBox[
                         PaneBox[
-                            PaneBox[ #1, ImageSize -> Dynamic[ Function[ If[ # > 540, #, 540 ] ][ 0.95*AbsoluteCurrentValue[ { WindowSize, 1 } ] ] ] ],
+                            #1,
                             AppearanceElements -> None,
+                            BaseStyle          -> { LineBreakWithin -> False },
                             ImageSize          -> { Scaled[ 1 ], UpTo[ 400 ] },
                             Scrollbars         -> Automatic
                         ],

--- a/FrontEnd/Assets/Extensions/CoreExtensions.nb
+++ b/FrontEnd/Assets/Extensions/CoreExtensions.nb
@@ -11,7 +11,7 @@ Notebook[
   Cell["Chatbook Core.nb Extensions", "Title"],
   Cell[
    StyleData["ChatStyleSheetInformation"],
-   TaggingRules -> <|"StyleSheetVersion" -> "2.5.56.3980325675"|>
+   TaggingRules -> <|"StyleSheetVersion" -> "2.5.68.3981191117"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Text"],
@@ -4212,16 +4212,9 @@ Notebook[
         {
          FrameBox[
           PaneBox[
-           PaneBox[
-            #1,
-            ImageSize ->
-             Dynamic[
-              If[#1 > 540, #1, 540] &[
-               0.95 * AbsoluteCurrentValue[{WindowSize, 1}]
-              ]
-             ]
-           ],
+           #1,
            AppearanceElements -> None,
+           BaseStyle -> {LineBreakWithin -> False},
            ImageSize -> {Scaled[1], UpTo[400]},
            Scrollbars -> Automatic
           ],
@@ -4453,7 +4446,7 @@ Notebook[
    StyleData[
     "NotebookAssistant`Sidebar`StyleSheetInformation"
    ],
-   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.5.53.3979960907"|>
+   TaggingRules -> <|"WorkspaceChatStyleSheetVersion" -> "2.5.65.3981005767"|>
   ],
   Cell[
    StyleData["NotebookAssistant`Sidebar`ToolbarButtonLabel"],


### PR DESCRIPTION
I have a feeling we may undo this change due to feedback from users, but this improves UI performance and IMO appearance.