### PR TITLE
When reading Cell expressions, ignore stale CellObjects

### DIFF
--- a/Source/Chatbook/FrontEnd.wl
+++ b/Source/Chatbook/FrontEnd.wl
@@ -947,7 +947,7 @@ notebookRead // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*cloudNotebookRead*)
 cloudNotebookRead // beginDefinition;
-cloudNotebookRead[ cells: { ___CellObject } ] := notebookReadWithCellObjects /@ cells;
+cloudNotebookRead[ cells: { ___CellObject } ] := notebookReadWithCellObjects /@ cells // DeleteMissing;
 cloudNotebookRead[ cell_ ] := notebookReadWithCellObjects @ cell;
 cloudNotebookRead // endDefinition;
 
@@ -964,8 +964,9 @@ notebookReadWithCellObjects // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*appendCellObject*)
 appendCellObject // beginDefinition;
+appendCellObject[ $Failed, obj_CellObject ] := Missing[ "CellNotAvailable" ]
 appendCellObject[ Cell[ a___ ], obj_CellObject ] := Cell[ a, CellObject -> obj ];
-appendCellObject[ cells: { ___Cell }, objs: { ___CellObject } ] := MapThread[ appendCellObject, { cells, objs } ];
+appendCellObject[ cells: { (_Cell|$Failed)... }, objs: { ___CellObject } ] := DeleteMissing @ MapThread[ appendCellObject, { cells, objs } ];
 appendCellObject // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
The finite lifetime of a CellObject means that if we try to get their Cell expression then we may fail. Let's not always issue an internal error if generating a large number of Cell expressions and a few happen to fail.