### PR TITLE
Enable WebFetcher tool for CodeAssistant and NotebookAssistant

### DIFF
--- a/LLMConfiguration/Personas/CodeAssistant/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/CodeAssistant/LLMConfiguration.wl
@@ -4,5 +4,11 @@
     "DisplayName"      -> Dynamic @ FEPrivate`FrontEndResource[ "ChatbookStrings", "PersonaNameCodeAssistant" ],
     "Icon"             -> Dynamic @ RawBoxes @ FEPrivate`FrontEndResource[ "ChatbookExpressions", "ChatOutputCellDingbat" ],
 	"PromptGenerators" -> { "RelatedDocumentation", ParentList },
-    "Tools"            -> { "WolframLanguageEvaluator", "DocumentationSearcher", "WolframAlpha", ParentList }
+    "Tools"            -> {
+        "WolframLanguageEvaluator",
+        "DocumentationSearcher",
+        "WolframAlpha",
+        "WebFetcher",
+        ParentList
+    }
 |>

--- a/LLMConfiguration/Personas/NotebookAssistant/LLMConfiguration.wl
+++ b/LLMConfiguration/Personas/NotebookAssistant/LLMConfiguration.wl
@@ -10,6 +10,7 @@
         "DocumentationSearcher",
         "WolframAlpha",
         "CreateNotebook",
+        "WebFetcher",
         ParentList
     }
 |>

--- a/Source/Chatbook/Tools/Common.wl
+++ b/Source/Chatbook/Tools/Common.wl
@@ -52,7 +52,7 @@ $ToolFunctions = <|
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Tool Configuration*)
-$defaultWebTextLength    = 12000;
+$defaultWebTextLength    = 2^16;
 $toolResultStringLength := Ceiling[ $initialCellStringBudget/2 ];
 $webSessionVisible       = False;
 

--- a/Tests/GenerateLLMConfiguration.wlt
+++ b/Tests/GenerateLLMConfiguration.wlt
@@ -61,7 +61,7 @@ VerificationTest[
 (*Tools*)
 VerificationTest[
     Sort[ #[ "Data" ][ "CanonicalName" ] & /@ GenerateLLMConfiguration[ "NotebookAssistant" ][ "Tools" ] ],
-    { "CreateNotebook", "DocumentationSearcher", "WolframAlpha", "WolframLanguageEvaluator" },
+    { "CreateNotebook", "DocumentationSearcher", "WebFetcher", "WolframAlpha", "WolframLanguageEvaluator" },
     SameTest -> MatchQ,
     TestID   -> "Named-Tools@@Tests/GenerateLLMConfiguration.wlt:62,1-67,2"
 ]


### PR DESCRIPTION
## Summary
- Add `WebFetcher` to the default tool list for the CodeAssistant and NotebookAssistant personas
- Increase `$defaultWebTextLength` from 12000 to 2^16 (65536) so fetched page content has more headroom

## Test plan
- [x] Open a chat with the CodeAssistant persona and confirm WebFetcher is available and works on a representative URL
- [x] Repeat with the NotebookAssistant persona
- [x] Fetch a large page and verify the response is truncated to the new 2^16 limit rather than 12000
- [x] Run `wolframscript -f Scripts/TestPaclet.wls` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)