### PR TITLE
Suppress messages from MakeBoxes calls in Sandbox

### DIFF
--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -2894,7 +2894,7 @@ simpleFormattingQ // Attributes = { HoldAllComplete };
 simpleFormattingQ[ _String ] := True;
 
 simpleFormattingQ[ e_ ] := simpleFormattingQ[ HoldPattern @ Verbatim[ e ] ] =
-    simpleFormattingQ0[ Unevaluated @ MakeBoxes @ e /. markdownExpression[ str_String ] :> str ];
+    simpleFormattingQ0[ Unevaluated @ Quiet @ MakeBoxes @ e /. markdownExpression[ str_String ] :> str ];
 
 simpleFormattingQ // endDefinition;
 
@@ -2975,7 +2975,7 @@ sandboxFormatter[ KeyValuePattern[ "Result" -> result_ ], "Result" ] :=
     sandboxFormatter[ result, "Result" ];
 
 sandboxFormatter[ result_, "Result" ] :=
-    RawBoxes @ makeInteractiveCodeCell[ "Wolfram", Cell[ BoxData @ MakeBoxes @ result, "Input" ] ];
+    RawBoxes @ makeInteractiveCodeCell[ "Wolfram", Cell[ BoxData @ Quiet @ MakeBoxes @ result, "Input" ] ];
 
 sandboxFormatter[ result_, ___ ] := result;
 
@@ -3038,7 +3038,7 @@ makeCachedBoxesQ // endDefinition;
 (*makeCachedBoxes*)
 makeCachedBoxes // beginDefinition;
 makeCachedBoxes // Attributes = { HoldAllComplete };
-makeCachedBoxes[ expr_ ] := Verbatim[ makeCachedBoxes @ expr ] = MakeBoxes @ expr;
+makeCachedBoxes[ expr_ ] := Verbatim[ makeCachedBoxes @ expr ] = Quiet @ MakeBoxes @ expr;
 makeCachedBoxes // endDefinition;
 
 (* ::**************************************************************************************************************:: *)


### PR DESCRIPTION
## Summary
- Wrap `MakeBoxes` invocations in `simpleFormattingQ`, `sandboxFormatter`, and `makeCachedBoxes` with `Quiet` to prevent extraneous messages from leaking through during box formatting.

## Test plan
- [ ] Verify no spurious messages appear when formatting sandbox results that previously triggered `MakeBoxes` warnings
- [ ] Confirm formatting output for typical sandbox results is unchanged
- [ ] Run existing Sandbox tests via `Scripts/TestPaclet.wls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)