### PR TITLE
Choose default LLMKit model based on access level

### DIFF
--- a/Source/Chatbook/CommonSymbols.wl
+++ b/Source/Chatbook/CommonSymbols.wl
@@ -217,6 +217,7 @@ BeginPackage[ "Wolfram`Chatbook`Common`" ];
 `getEmbeddings;
 `getHandlerFunctions;
 `getInlineChatPrompt;
+`getLLMKitInfo;
 `getModelList;
 `getPersonaIcon;
 `getPersonaMenuIcon;

--- a/Source/Chatbook/Models.wl
+++ b/Source/Chatbook/Models.wl
@@ -13,12 +13,79 @@ Needs[ "Wolfram`Chatbook`UI`"      ];
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Configuration*)
-$defaultLLMKitService  := Replace[ $llmKitService, Except[ _String ] :> "AzureOpenAI" ];
-$defaultLLMKitModelName = "gpt-5.4-2026-03-05";
+(* Add additional supported models here as needed: *)
+$llmKitPreferredModels = <|
+    "Pro"      -> { "gpt-5.4" },
+    "Research" -> { "gpt-5.4" },
+    "Basic"    -> { "gpt-5.4-mini" }
+|>;
+
+$$llmKitAccessLevel = Alternatives @@ Keys @ $llmKitPreferredModels;
+
+$defaultLLMKitService   := Replace[ $llmKitService, Except[ _String ] :> "AzureOpenAI" ];
+$defaultLLMKitModelName := defaultLLMKitModelName[ ];
+$fallbackLLMKitModelName = "gpt-5.4-2026-03-05";
 
 $$modelVersion = DigitCharacter.. ~~ (("." ~~ DigitCharacter...) | "");
 
 $defaultModelIcon = "";
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*LLMKit*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*defaultLLMKitModelName*)
+defaultLLMKitModelName // beginDefinition;
+
+defaultLLMKitModelName[ ] :=
+    defaultLLMKitModelName @ getLLMKitInfo[ ];
+
+defaultLLMKitModelName[ None ] :=
+    $fallbackLLMKitModelName;
+
+defaultLLMKitModelName[ as_Association ] :=
+    defaultLLMKitModelName[ as[ "accessLevel" ], as[ "availableModels" ] ];
+
+defaultLLMKitModelName[ level: $$llmKitAccessLevel, models_ ] := Enclose[
+    ConfirmBy[ chooseFirstAvailableModel[ level, models ], StringQ, "ModelName" ],
+    throwInternalFailure
+];
+
+defaultLLMKitModelName[ _, _ ] :=
+    $fallbackLLMKitModelName;
+
+defaultLLMKitModelName // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*chooseFirstAvailableModel*)
+chooseFirstAvailableModel // beginDefinition;
+
+chooseFirstAvailableModel[ level_String, models_ ] := Enclose[
+    Module[ { preferred, available },
+        preferred = ConfirmMatch[ Lookup[ $llmKitPreferredModels, level ], { __String }, "PreferredModels" ];
+        available = ConfirmMatch[ extractModelNames @ models, { ___String }, "AvailableModels" ];
+        FirstCase[ preferred, Alternatives @@ available, First @ preferred ]
+    ],
+    throwInternalFailure
+];
+
+chooseFirstAvailableModel // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*extractModelNames*)
+extractModelNames // beginDefinition;
+extractModelNames[ _Missing ] := { };
+extractModelNames[ models_List ] := Flatten[ extractModelNames /@ models ];
+extractModelNames[ KeyValuePattern[ "ChatCompletion" -> models_List ] ] := extractModelNames @ models;
+extractModelNames[ KeyValuePattern[ "ChatCompletion" -> models_Association ] ] := extractModelNames @ Values @ models;
+extractModelNames[ KeyValuePattern @ { "model" -> name_String, "type" -> "ChatCompletion" } ] := name;
+extractModelNames[ KeyValuePattern[ "type" -> _ ] ] := Nothing;
+extractModelNames[ name_String ] := name;
+extractModelNames // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)

--- a/Source/Chatbook/Services.wl
+++ b/Source/Chatbook/Services.wl
@@ -55,41 +55,55 @@ InvalidateServiceCache // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
-(*llmKitCheck*)
-llmKitCheck // beginDefinition;
+(*getLLMKitInfo*)
+getLLMKitInfo // beginDefinition;
 
-llmKitCheck[ ] :=
-    LogChatTiming @ llmKitCheck[ $CloudUserID, $CloudBase ];
+getLLMKitInfo[ ] := LogChatTiming @ getLLMKitInfo[ $CloudUserID, $CloudBase ];
 
-llmKitCheck[ _, cloud_String ] := Enclose[
-    Module[ { check, user },
-        check = ConfirmMatch[ llmKitCheck0[ ], _Success|_Failure, "Check" ];
-        If[ FailureQ @ check, throwFailureToChatOutput @ check ];
+getLLMKitInfo[ _, cloud_String ] := Enclose[
+    Catch @ Module[ { info, user },
+        info = ConfirmMatch[ getLLMKitInfo0[ ], _Association|None, "Info" ];
+        If[ info === None, Throw @ None ];
         user = ConfirmBy[ $CloudUserID, StringQ, "CloudUserID" ];
-        llmKitCheck[ user, cloud ] = check
+        getLLMKitInfo[ user, cloud ] = info
     ],
     throwInternalFailure
 ];
 
-llmKitCheck // endDefinition;
+getLLMKitInfo // endDefinition;
 
 
-llmKitCheck0 // beginDefinition;
+getLLMKitInfo0 // beginDefinition;
 
-llmKitCheck0[ ] := Replace[
+getLLMKitInfo0[ ] := (
     LLMSynthesize;
     Wolfram`LLMFunctions`Common`UpdateLLMKitInfo[ ];
-    Wolfram`LLMFunctions`Common`LLMKitCheck[ ],
-    Null :> Wolfram`LLMFunctions`Common`LLMKitCheck[ ]
+    Wolfram`LLMFunctions`Common`$LLMKitInfo
+);
+
+getLLMKitInfo0 // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*llmKitCheck*)
+llmKitCheck // beginDefinition;
+
+llmKitCheck[ ] := LogChatTiming[
+    getLLMKitInfo[ ];
+    Replace[
+        Wolfram`LLMFunctions`Common`LLMKitCheck[ ],
+        Null :> Wolfram`LLMFunctions`Common`LLMKitCheck[ ]
+    ],
+    "LLMKitCheck"
 ];
 
-llmKitCheck0 // endDefinition;
+llmKitCheck // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
 (*getLLMKitService*)
 getLLMKitService // beginDefinition;
-getLLMKitService[ ] := (LLMSynthesize; getLLMKitService @ Wolfram`LLMFunctions`Common`$LLMKitInfo);
+getLLMKitService[ ] := getLLMKitService @ getLLMKitInfo[ ];
 getLLMKitService[ KeyValuePattern[ "currentProvider" -> service_String ] ] := $llmKitPrefix <> service;
 getLLMKitService[ None ] := getUpdatedLLMKitService[ ];
 getLLMKitService[ _ ] := $fallbackLLMKitService;
@@ -102,9 +116,7 @@ getUpdatedLLMKitService // beginDefinition;
 
 getUpdatedLLMKitService[ ] := Enclose[
     Catch @ Module[ { provider, info, service },
-        LLMSynthesize;
-        Wolfram`LLMFunctions`Common`UpdateLLMKitInfo[ ];
-        info = ConfirmMatch[ Wolfram`LLMFunctions`Common`$LLMKitInfo, _Association|None, "Info" ];
+        info = ConfirmMatch[ getLLMKitInfo[ ], _Association|None, "Info" ];
         If[ info === None, Throw @ $fallbackLLMKitService ];
         If[ ! KeyExistsQ[ info, "currentProvider" ] && info[ "service" ] === "llmkit", Throw @ $fallbackLLMKitService ];
         provider = ConfirmBy[ info[ "currentProvider" ], StringQ, "Provider" ];

--- a/Source/Chatbook/Services.wl
+++ b/Source/Chatbook/Services.wl
@@ -62,7 +62,8 @@ getLLMKitInfo[ ] := LogChatTiming @ getLLMKitInfo[ $CloudUserID, $CloudBase ];
 
 getLLMKitInfo[ _, cloud_String ] := Enclose[
     Catch @ Module[ { info, user },
-        info = ConfirmMatch[ getLLMKitInfo0[ ], _Association|None, "Info" ];
+        info = ConfirmMatch[ getLLMKitInfo0[ ], _Association|_Failure|None, "Info" ];
+        If[ FailureQ @ info, throwFailureToChatOutput @ info ];
         If[ info === None, Throw @ None ];
         user = ConfirmBy[ $CloudUserID, StringQ, "CloudUserID" ];
         getLLMKitInfo[ user, cloud ] = info
@@ -91,8 +92,11 @@ llmKitCheck // beginDefinition;
 llmKitCheck[ ] := LogChatTiming[
     getLLMKitInfo[ ];
     Replace[
-        Wolfram`LLMFunctions`Common`LLMKitCheck[ ],
-        Null :> Wolfram`LLMFunctions`Common`LLMKitCheck[ ]
+        Replace[
+            Wolfram`LLMFunctions`Common`LLMKitCheck[ ],
+            Null :> Wolfram`LLMFunctions`Common`LLMKitCheck[ ]
+        ],
+        fail_Failure :> throwFailureToChatOutput @ fail
     ],
     "LLMKitCheck"
 ];


### PR DESCRIPTION
## Summary
- Refactor `llmKitCheck` into `getLLMKitInfo`, which returns the cached `$LLMKitInfo` association (or `None`) so callers can read `accessLevel` and `availableModels` without re-querying.
- Replace the hard-coded `$defaultLLMKitModelName` with a lookup that picks the first available model from a per-plan preference list (`Pro`/`Research` → `gpt-5.4`, `Basic` → `gpt-5.4-mini`), falling back to `gpt-5.4-2026-03-05`.
- Reroute `getLLMKitService` and `getUpdatedLLMKitService` through `getLLMKitInfo` so the info association is fetched once and reused.

## Test plan
- [ ] `wolframscript -f Scripts/TestPaclet.wls` passes.
- [ ] On a Pro/Research account, the default LLMKit model resolves to `gpt-5.4` (or the configured preferred variant) when available.
- [ ] On a Basic account, the default LLMKit model resolves to `gpt-5.4-mini` when available.
- [ ] When `availableModels` is missing or the access level is unrecognized, the fallback `gpt-5.4-2026-03-05` is used.
- [ ] When not signed in / no LLMKit info, chat still works using the fallback model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)