### PR TITLE
Set ServiceCaller for chatbar evaluations

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
         "Autoload",
         "Bezier",
         "Birdnardo",
+        "Chatbar",
         "Chatbook",
         "Checkmark",
         "Checkmarked",

--- a/Source/Chatbook/ChatModes/ShowNotebookAssistance.wl
+++ b/Source/Chatbook/ChatModes/ShowNotebookAssistance.wl
@@ -24,7 +24,6 @@ $notebookAssistanceBaseSettings = <|
     "MaxToolResponses"          -> 5,
     "Model"                     -> <| "Service" -> "LLMKit", "Name" -> Automatic |>,
     "PromptGenerators"          -> { "RelatedDocumentation" },
-    "ServiceCaller"             -> "NotebookAssistance",
     "Tools"                     -> { "NotebookEditor" },
     "ToolOptions"               -> <|
         "WolframLanguageEvaluator" -> <| "AppendURIPrompt" -> True, "Method" -> "Session" |>
@@ -78,8 +77,6 @@ $workspaceChatNotebookOptions := Sequence[
         "ConversationTitle"    -> ""
     |>
 ];
-
-(* TODO: set $serviceCaller from chat settings *)
 
 $$notebookAssistanceMenuItem = "Inline"|"Window"|"ContentSuggestions";
 
@@ -428,7 +425,7 @@ autoShowNotebookAssistance[ "CellInsertionPoint", obj0_, opts: OptionsPattern[ ]
                 "NotebookAssistant`Sidebar`ChatInput",
                 (* If we were writing this CellObject as a top-level cell then we could use ExpressoinUUID to coerce the front end use a pre-specified UUID.
                     However, the side bar is a more complicated Cell within a Cell and in that case the ExpressoinUUID is dropped. *)
-                CellTags -> uuid 
+                CellTags -> uuid
             ];
 
         If[ sidebarInfo === None,
@@ -446,9 +443,9 @@ autoShowNotebookAssistance[ "CellInsertionPoint", obj0_, opts: OptionsPattern[ ]
                 (* sidebar is currently open: do something sensible *)
                 cellObject = appendCellToSidebarChat[ nbo, sidebarCell, newCell, uuid ];
                 ConfirmMatch[ ChatCellEvaluate[ cellObject, nbo ], _ChatObject|Null, "ChatCellEvaluate" ]
-                
+
                 , (* ELSE the sidebar has been opened before, but isn't now, so open it again as a new chat with the helping prompt *)
-                
+
                 FrontEndTokenExecute[ nbo, "SwitchSidebar", <| "PanelID" -> "NotebookAssistant", "PreferredSize" -> $sidebarChatWidth @ nbo |> ];
                 NotebookDelete @ Cells[ nbo, CellStyle -> "AttachedOverlayMenu", AttachedCell -> True ];
                 NotebookDelete /@ Cells[ sidebarCell, CellTags -> "SidebarSourcesDockedCell" | "SidebarChatTitleCell" ];
@@ -610,7 +607,7 @@ showNotebookAssistanceSidebar[ nbo_NotebookObject, input_, evaluate_, toggle_, s
         If[ nbo === MessagesNotebook[ ], Return @ Null ]; (* prevent sidebar from opening in messages window *)
 
         sidebarCell = sidebarCellObject @ nbo; (* if the side bar has been opened once before IN ITS CONTAINING NOTEBOOK than this is a CellObject, else $Failed *)
-        
+
         Which[
             FailureQ @ sidebarCell,
                  (* don't do anything else because this is the first time we've opened the sidebar in this notebook *)
@@ -619,7 +616,7 @@ showNotebookAssistanceSidebar[ nbo_NotebookObject, input_, evaluate_, toggle_, s
                 sidebarCell = sidebarCellObject @ nbo;
                 chatInputCell = First[ Cells[ sidebarCell, CellStyle -> "ChatInputField" ], None ];
                 If[ chatInputCell =!= None, FrontEnd`MoveCursorToInputField[ nbo, "AttachedChatInputField", chatInputCell, chatInputCell ] ],
-            
+
             TrueQ @ toggle,
                 If[ TrueQ @ FE`Evaluate @ FEPrivate`SidebarExtensionInformation[ nbo, { "NotebookAssistant", "Active" } ],
                     FrontEndTokenExecute[ nbo, "HideSidebar" ]
@@ -629,13 +626,13 @@ showNotebookAssistanceSidebar[ nbo_NotebookObject, input_, evaluate_, toggle_, s
                     chatInputCell = First[ Cells[ sidebarCell, CellStyle -> "ChatInputField" ], None ];
                     If[ chatInputCell =!= None, FrontEnd`MoveCursorToInputField[ nbo, "AttachedChatInputField", chatInputCell, chatInputCell ] ]
                 ],
-            
+
             (* The sidebar assistant is persistant to a given notebook. *)
             True,
                 FrontEndTokenExecute[ nbo, "SwitchSidebar", <| "PanelID" -> "NotebookAssistant", "PreferredSize" -> $sidebarChatWidth @ nbo |> ];
                 chatInputCell = First[ Cells[ sidebarCell, CellStyle -> "ChatInputField" ], None ];
                 If[ chatInputCell =!= None, FrontEnd`MoveCursorToInputField[ nbo, "AttachedChatInputField", chatInputCell, chatInputCell ] ];
-                
+
                 (* will we ever need to do this with the sidebar chat...? *)
                 If[ TrueQ @ evaluate,
                     MathLink`CallFrontEnd @ FrontEnd`TriggerControlBoxObject @

--- a/Source/Chatbook/ChatModes/UI.wl
+++ b/Source/Chatbook/ChatModes/UI.wl
@@ -925,7 +925,7 @@ Button[
     Method           -> "Preemptive"
 ]
 
-$chatbarOptionsAttachment[ ] := 
+$chatbarOptionsAttachment[ ] :=
     With[ { offset = If[ $OperatingSystem === "MacOSX", { -15., 55. }, { -13., 45. } ] },
         {
             { Right, Bottom },
@@ -971,7 +971,7 @@ chatbarUserData[ rawAccessData_ ] := $chatbarAccessFailedData /; Or[
     If we've made it this far, credentials are present, and rawAccessData is an
     Association with "success" -> True, and "data" is set to an Association.
 *)
-chatbarUserData[ rawAccessData_ ] := 
+chatbarUserData[ rawAccessData_ ] :=
     With[ { assoc = Lookup[ rawAccessData, "data" ] },
         AssociationMap[ getUserValue[ assoc, # ]&, {
             "credentialsQ",
@@ -1015,11 +1015,11 @@ getUserValue[ assoc_, "usage" ] :=
         If[ remaining <= 0, remaining = 0 ];
         If[ allotment <= 0, allotment = 1 ]; (* avoid division by zero *)
         If[ used <= 0, used = 0 ];
-        
+
         Clip[ (used) / (allotment + remaining), { 0, 1 } ]
     ]
 
-getUserValue[ assoc_, "daysToReset" ] := 
+getUserValue[ assoc_, "daysToReset" ] :=
     Module[ { date, remaining },
         date = DateObject @ Lookup[ assoc, "resetTimestamp" ];
         If[
@@ -1033,10 +1033,10 @@ getUserValue[ assoc_, "daysToReset" ] :=
         ]
     ]
 
-getUserValue[ assoc_, "upgradeURL" ] := 
+getUserValue[ assoc_, "upgradeURL" ] :=
     Lookup[ assoc, "upgradeUrl", "https://www.wolfram.com/wolfram-ai-services" ]
 
-getUserValue[ assoc_, "serviceCreditsOptions" ] := 
+getUserValue[ assoc_, "serviceCreditsOptions" ] :=
     Lookup[ assoc, "serviceCreditsOptions", { } ]
 
 
@@ -1188,12 +1188,12 @@ chatbarOptionsUser[ userdata_ ] :=
                 Pane[
                     RawBoxes[
                         DynamicBox[ FEPrivate`FrontEndResource[ "FEBitmaps", "GenericUserIcon" ][ # ] ]&[
-                             LightDarkSwitched[ GrayLevel[ 0.2 ], GrayLevel[ 0.960784 ] ]      
+                             LightDarkSwitched[ GrayLevel[ 0.2 ], GrayLevel[ 0.960784 ] ]
                         ]
                     ],
                     BaselinePosition -> Scaled[ 0.15 ],
                     ImageSize        -> Dynamic[ { Automatic, 1.25*CurrentValue[ "FontLineHeight" ] } ],
-                    ImageSizeAction  -> "ShrinkToFit"                    
+                    ImageSizeAction  -> "ShrinkToFit"
                 ],
                 Lookup[ userdata, "username" ],
                 chatbarOptionsArrowDown[ ]
@@ -1212,7 +1212,7 @@ chatbarOptionsUser[ userdata_ ] :=
     ]
 
 
-chatbarOptionsArrowDown[ ] := 
+chatbarOptionsArrowDown[ ] :=
     Pane[
         RawBoxes[
             DynamicBox[ FEPrivate`FrontEndResource[ "FEBitmaps", "ArrowDownIcon" ][ # ] ]&[
@@ -1283,7 +1283,7 @@ chatbarUsageThermometerBase[ width_, usage_, label_, size_ : Automatic ] :=
                             ImageMargins   -> { { $cutMargin, 3*$cutMargin-1 } + {-4,4}, { $cutMargin, $cutMargin } + {-1,1} },
                             ImageSize -> {$cutHeight - 2*$cutMargin, $cutHeight - 2*$cutMargin}
                         ],
-                            
+
                         Framed[ label,
                             Background     -> LightDarkSwitched @ GrayLevel[ 1, 0.8 ],
                             BaselinePosition -> Center -> Center,
@@ -1333,7 +1333,7 @@ chatbarUsageThermometerCap[ width_, label_, ellipsisQ_ : False ] :=
                                 { { 0, 0 }, { width, 0 } },
                                 { { width, $cutHeight }, { 0, $cutHeight } }
                             } ]
-    
+
                         ]
                     },
                     AspectRatio      -> Full,
@@ -1489,7 +1489,7 @@ chatbarUpgradeStripe[ userdata_, tier: "Pro", usage_, url_, creditsOptions_ ] :=
                             ],
                             Style[ "\[ThickSpace]\[RightGuillemet]", FontColor -> $cutBlueHover, FontWeight -> "DemiBold" ]
                         }, BaseStyle -> { FontColor -> $coBodyColorHover } ]
-                    
+
                     ],
                     SystemOpen @ url,
                     Appearance       -> None,
@@ -1518,7 +1518,7 @@ chatbarUpgradeStripe[ userdata_, tier: "Research", usage_, url_, creditsOptions_
 chatbarAddServiceCreditsButton[ userdata_, tier_, creditsOptions_ ] :=
     Module[ { creditChoices, amounts, widths },
         (*
-            creditsChoices contains those elements of creditsOptions which 
+            creditsChoices contains those elements of creditsOptions which
             have appropriate settings for "url" and "amount". We also add
             a "width" key below, for thermometer drawing.
         *)
@@ -1526,12 +1526,12 @@ chatbarAddServiceCreditsButton[ userdata_, tier_, creditsOptions_ ] :=
             creditsOptions,
             AssociationQ[ # ] && StringQ[ Lookup[ #, "url" ] ] && NumericQ[ Lookup[ #, "amount" ] ] &
         ];
-        
+
         (* log-rescale the amounts to get widths from 50 to 250 *)
         amounts = Lookup[ creditChoices, "amount" ] // N;
         widths = Rescale[ Log @ amounts, Log @ MinMax @ amounts, If[ tier === "Pro", { 50, 200 }, { 50, 260 } ] ];
         creditChoices = MapThread[ Append[ #1, "width" -> #2 ]&, { creditChoices, widths } ];
-        
+
         If[ creditChoices === { },
             Nothing,
             With[ { creditChoices = creditChoices },
@@ -1584,7 +1584,7 @@ chatbarAddServiceCreditsDisplay[ userdata_, tier: "Pro", creditChoices_ ] :=
         Grid[
             Append[
                 Table[
-                    { 
+                    {
                         Hyperlink[
                             Row[ { Round @ assoc[ "amount" ], " ", tr @ "ChatbarOptionsCredits" } ],
                             assoc[ "url" ]
@@ -1696,7 +1696,7 @@ chatbarStateSetter[ nbo_NotebookObject, Dynamic[ localSetting_ ], state_ ] :=
                 Spacings         -> 0.7
             ],
             BaselinePosition -> Baseline,
-            ImageMargins     -> 10            
+            ImageMargins     -> 10
         ],
         localSetting = state,
         Appearance       -> "Suppressed",
@@ -1818,10 +1818,10 @@ makeChatbarChatInputCellContent[ nbo_NotebookObject, initialText_:"" ] :=
                                                 !MemberQ[ #, "LLMSupport" ]&
                                             ],
                                                 "LocalAIOnly",
-                                            
+
                                             MatchQ[ CurrentValue[ "WolframCloudConnected" ], False | "Pending" ],
                                                 "SignIn",
-                                            
+
                                             (* ======= Check ERP for AI access ======= *)
                                             Typeset`WolframAccountInfo = CurrentValue[ "WolframAccountInformation" ];
 
@@ -1841,7 +1841,7 @@ makeChatbarChatInputCellContent[ nbo_NotebookObject, initialText_:"" ] :=
                                                 # === False&
                                             ],
                                                 "LocalAIOnly",
-                                            
+
                                             (* ======= success ======= *)
                                             True,
                                                 "Enabled"
@@ -2280,8 +2280,12 @@ chatbarWriteAndEvaluateChatInputCell[ nbo_NotebookObject, chatbarCell_CellObject
             (* 476251: chatbar only uses Wolfram services and assistant *)
             TaggingRules -> <|
                 "ChatNotebookSettings" -> <|
-                    "Model"        -> <| "Service" -> "LLMKit", "Name" -> Automatic |>,
-                    "LLMEvaluator" -> "WolframAIAssistant" |> |> ];
+                    "Model"         -> <| "Service" -> "LLMKit", "Name" -> Automatic |>,
+                    "LLMEvaluator"  -> "WolframAIAssistant",
+                    "ServiceCaller" -> "Chatbar"
+                |>
+            |>
+        ];
 
         currentSelections = Replace[ FE`Evaluate @ FEPrivate`GetCurrentSelections @ nbo, Except[ _Association ] -> <| |> ];
         activeSelection = Lookup[ currentSelections, "ActiveSelection", None ];

--- a/Source/Chatbook/ChatState.wl
+++ b/Source/Chatbook/ChatState.wl
@@ -88,6 +88,7 @@ withChatState[ eval_ ] :=
             $excludedBasePrompts          = $excludedBasePrompts,
             $disabledBasePrompts          = $disabledBasePrompts,
             $endToken                     = $endToken,
+            $serviceCaller                = None,
 
             (* Values used for token budgets during cell serialization: *)
             $cellStringBudget             = $cellStringBudget,

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -880,7 +880,7 @@ chatbookServiceCaller // beginDefinition;
 chatbookServiceCaller[ ] := Flatten @ {
     If[ TrueQ @ $InlineChat, "InlineChat", Nothing ],
     If[ TrueQ @ $WorkspaceChat, "WorkspaceChat", Nothing ],
-    If[ TrueQ @ $SidebarChat, "WorkspaceChat", Nothing ],
+    If[ TrueQ @ $SidebarChat, "SidebarChat", Nothing ],
     Replace[ $serviceCaller, Except[ $$serviceCaller ] -> Nothing ]
 };
 

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -802,6 +802,7 @@ resolveAutoSettings[ settings0_Association ] := Enclose[
             $excludedBasePrompts     = DeleteDuplicates @ Select[ resolved[ "ExcludedBasePrompts" ], StringQ ];
             $disabledBasePrompts     = Complement[ $disabledBasePrompts, Flatten @ { resolved[ "EnabledBasePrompts" ] } ];
             $endToken                = resolved[ "EndToken" ];
+            $serviceCaller           = resolved[ "ServiceCaller" ];
 
             If[ resolved[ "ShowProgressText" ] || resolved[ "ForceSynchronous" ], $showProgressText = True ];
 


### PR DESCRIPTION
## Summary

Wires the chat `ServiceCaller` setting through to evaluations so the chatbar identifies itself correctly to the service framework, and fixes a mislabeled sidebar caller.

- **Resolve `$serviceCaller` from chat settings.** `resolveAutoSettings` now reads `$serviceCaller` from the resolved `"ServiceCaller"` setting, and `withChatState` scopes it (default `None`). A chat can now configure its service caller through its settings instead of relying on hardcoded values.
- **Tag chatbar evaluations.** The chatbar sets `ServiceCaller -> "Chatbar"` in its `ChatNotebookSettings`, so `chatbookServiceCaller` reports `"Chatbar"` for those evaluations. Added `"Chatbar"` to the cspell dictionary.
- **Remove inert hardcoded caller.** Dropped `ServiceCaller -> "NotebookAssistance"` from the notebook assistance base settings, along with the stale `(* TODO: set $serviceCaller from chat settings *)`, now that the caller flows through the resolved setting.
- **Fix sidebar caller label.** `chatbookServiceCaller` returned `"WorkspaceChat"` for sidebar chats; it now correctly returns `"SidebarChat"`.

## Test plan

- [ ] Build/load the paclet and confirm it loads without errors.
- [ ] Evaluate from the chatbar and confirm the active caller (``ServiceFramework`$Caller`` / ``ServiceConnectionUtilities`$Caller``) includes `"Chatbar"`.
- [ ] Evaluate from a sidebar chat and confirm the caller includes `"SidebarChat"` (not `"WorkspaceChat"`).
- [ ] Evaluate from inline and workspace chats and confirm their callers are unchanged (`"InlineChat"`, `"WorkspaceChat"`).
- [ ] Run the test suite: `wolframscript -f Scripts/TestPaclet.wls`.
