### PR TITLE
Allow Automatic model names to be resolved by the service connection

### DIFF
--- a/Source/Chatbook/ChatMessages.wl
+++ b/Source/Chatbook/ChatMessages.wl
@@ -1716,6 +1716,8 @@ tokenizerName[ name_String ] :=
         name
     ];
 
+tokenizerName[ Automatic ] := tokenizerName[ "gpt-4o" ];
+
 tokenizerName // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Source/Chatbook/Models.wl
+++ b/Source/Chatbook/Models.wl
@@ -213,7 +213,9 @@ toModelName[ KeyValuePattern @ { "Service" -> service_, "Name"|"Model" -> model_
 toModelName[ KeyValuePattern[ "Name"|"Model" -> model_ ] ] :=
     toModelName @ model;
 
-toModelName[ { service_String, name_String } ] := toModelName @ name;
+toModelName[ { service_String, name_ } ] := toModelName @ name;
+
+toModelName[ Automatic ] := Automatic;
 
 toModelName[ name_String? StringQ ] := toModelName[ name ] =
     If[ StringMatchQ[ name, "ft:"~~__~~":"~~__ ],
@@ -277,9 +279,12 @@ multimodalModelQ[ name_String? StringQ ] /; StringStartsQ[ name, "gpt-4-turbo-" 
 multimodalModelQ[ name_String? StringQ ] :=
     StringContainsQ[ toModelName @ name, WordBoundary~~"vision"~~WordBoundary, IgnoreCase -> True ];
 
+multimodalModelQ[ Automatic ] :=
+    False;
+
 multimodalModelQ[ other_ ] :=
     With[ { name = toModelName @ other },
-        multimodalModelQ @ name /; StringQ @ name
+        multimodalModelQ @ name /; MatchQ[ name, _String|Automatic ]
     ];
 
 multimodalModelQ // endDefinition;
@@ -799,15 +804,12 @@ standardizeModelData // endDefinition;
     Choose a default initial model according to the following rules:
         1. If the service name is the same as the one in $DefaultModel, use the model name in $DefaultModel.
         2. If the registered service specifies a "DefaultModel" property, we'll use that.
-        3. If the model list is already cached for the service, we'll use the first model in that list.
-        4. Otherwise, give Automatic to indicate a model name that must be resolved later.
+        3. Otherwise, give Automatic to let the service connection logic handle it.
 *)
 chooseDefaultModelName // beginDefinition;
 chooseDefaultModelName[ service_String ] /; service === $DefaultModel[ "Service" ] := $DefaultModel[ "Name" ];
 chooseDefaultModelName[ service_String ] := chooseDefaultModelName @ $availableServices @ service;
 chooseDefaultModelName[ KeyValuePattern[ "DefaultModel" -> model_ ] ] := toModelName @ model;
-chooseDefaultModelName[ KeyValuePattern[ "CachedModels" -> models_List ] ] := chooseDefaultModelName @ models;
-chooseDefaultModelName[ { model_, ___ } ] := toModelName @ model;
 chooseDefaultModelName[ service_ ] := Automatic;
 chooseDefaultModelName // endDefinition;
 
@@ -841,13 +843,10 @@ resolveFullModelSpec[ model: KeyValuePattern[ "Service" -> "LLMKit" ] ] :=
     |>;
 
 resolveFullModelSpec[ model: KeyValuePattern @ { "Service" -> service_String, "Name" -> Automatic } ] := Enclose[
-    Catch @ Module[ { default, models, name },
+    Catch @ Module[ { default },
         default = ConfirmMatch[ chooseDefaultModelName @ service, Automatic | _String, "Default" ];
         If[ StringQ @ default, Throw @ standardizeModelData @ <| model, "Name" -> default |> ];
-        models = ConfirmMatch[ getServiceModelList @ service, _List | Missing[ "NotConnected" ], "Models" ];
-        If[ MissingQ @ models, throwTop @ $Canceled ];
-        name = ConfirmBy[ chooseDefaultModelName @ models, StringQ, "ResolvedName" ];
-        standardizeModelData @ <| model, "Name" -> name |>
+        model
     ],
     throwInternalFailure
 ];

--- a/Source/Chatbook/PreferencesContent.wl
+++ b/Source/Chatbook/PreferencesContent.wl
@@ -46,7 +46,7 @@ createPreferencesContent[ ] := Enclose[
     Module[ { tabs, tabView, reset },
         (* Retrieve the dynamic content for each preferences tab, confirming that it matches the expected types: *)
         DynamicModule[ { tab, dmPrefCache, default, service, model, state, serviceSelector = $loadingPopupMenu, modelNameSelector = $loadingPopupMenu },
-            
+
             tabs = createTabViewTabs[ $displayedPreferencesPages, dmPrefCache, default, service, model, state, serviceSelector, modelNameSelector ];
 
             (* Create a TabView for the preferences content, with the tab state stored in the FE's private options: *)
@@ -83,12 +83,12 @@ createPreferencesContent[ ] := Enclose[
             Initialization   :> (
                 dmPrefCache = CurrentChatSettings[ $FrontEnd ];
                 tab = Lookup[ dmPrefCache, "CurrentPreferencesTab", "Services", Replace[ #, $$unspecified -> "Services" ]& ];
-                
+
                 default = Lookup[ dmPrefCache, "Model" ];
                 service = ConfirmBy[ extractServiceName @ default, StringQ, "ServiceName" ];
                 model   = ConfirmMatch[ extractModelName @ default, _String | Automatic, "ModelName" ];
                 state   = If[ modelListCachedQ @ service, "Loaded", "Loading" ];
-                
+
                 serviceSelector = makeServiceSelector[
                     <|
                         $availableServices,
@@ -283,7 +283,7 @@ localAIOnly[ ] := Which[
         !MemberQ[ #, "LLMSupport" ]&
     ],
         True,
-    
+
     (* if disabled via ERP *)
     Lookup[
         Lookup[ CurrentValue[ "WolframAccountInformation" ], "ServerMetadata", <| |>, Replace[ #, Except[ _Association?AssociationQ ] -> <| |> ]& ],
@@ -431,7 +431,7 @@ createNotebookSettingsPanel[ dmPrefCache_, default_, service_, model_, state_, s
             Spacings  -> { 0, 0.7 }
         ];
 
-        
+
         Pane[
             content,
             FrameMargins -> { { 8, 8 }, { 13, 13 } },
@@ -1225,7 +1225,7 @@ makeToolCallFrequencySelector[ Dynamic[ dmPrefCache_ ] ] := highlightControl[
             BaselinePosition -> 1,
             Spacings         -> 0.5
         ],
-        Initialization :> 
+        Initialization :>
             With[ { val = Lookup[ dmPrefCache, "ToolCallFrequency" ] },
                 type      = If[ NumberQ @ val, "Custom", Automatic ];
                 frequency = If[ NumberQ @ val, val, 0.5 ];
@@ -2039,6 +2039,12 @@ getServiceDefaultModel[ Dynamic[ dmPrefCache_ ], service_String ] := Enclose[
         (* If the service has not been selected before, choose a default model by service name and save it: *)
         If[ ! StringQ @ name,
             name = ConfirmMatch[ chooseDefaultModelName @ service, _String|Automatic, "DefaultName" ];
+            If[ name === Automatic,
+                Replace[
+                    getServiceModelList @ service,
+                    { KeyValuePattern[ "Name" -> s_String ], ___ } :> (name = s)
+                ]
+            ];
             lastSelected[ service ] = name;
             dmPrefCache[ "ServiceDefaultModel" ] = CurrentChatSettings[ $FrontEnd, "ServiceDefaultModel" ] = lastSelected;
         ];

--- a/Source/Chatbook/Services.wl
+++ b/Source/Chatbook/Services.wl
@@ -232,7 +232,8 @@ getServiceModelList[ service_String, info_, models0_List ] := Enclose[
     Module[ { models },
         models = ConfirmMatch[ preprocessModelList[ service, models0 ], { ___Association }, "Models" ];
         ConfirmAssert[ AssociationQ @ $serviceCache[ service ], "ServiceCache" ];
-        $serviceCache[ service, "CachedModels" ] = models;
+        (* Do not cache if model list is empty, since this usually indicates a retrieval error *)
+        If[ models =!= { }, $serviceCache[ service, "CachedModels" ] = models ];
         updateDynamics[ "Services" ];
         models
     ],

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -577,7 +577,7 @@ autoModelSetting[ model0_Association, key_String ] :=
         ]
     ];
 
-autoModelSetting[ service_String, name_String, id_String, family_String, key_String ] :=
+autoModelSetting[ service_String, name_, id_, family_, key_String ] :=
     autoModelSetting[ service, name, id, family, key ] =
         FirstCase[
             Unevaluated @ {
@@ -1253,6 +1253,7 @@ autoMaxContextTokens[ as_Association? llmKitQ ] := Min[ 2^16, autoMaxContextToke
 autoMaxContextTokens[ as_Association ] := autoMaxContextTokens[ as, as[ "Model" ] ];
 autoMaxContextTokens[ as_, model_ ] := autoMaxContextTokens[ as, model, toModelName @ model ];
 autoMaxContextTokens[ _, _, name_String ] := autoMaxContextTokens0 @ name;
+autoMaxContextTokens[ _, _, Automatic ] := 2^16;
 autoMaxContextTokens // endDefinition;
 
 autoMaxContextTokens0 // beginDefinition;
@@ -1271,7 +1272,7 @@ autoMaxContextTokens0[ { ___, "chat", "bison", "001"        , ___ } ] := 20000;
 autoMaxContextTokens0[ { ___, "gemini", ___, "pro", "vision", ___ } ] := 12288;
 autoMaxContextTokens0[ { ___, "gemini", ___, "pro"          , ___ } ] := 30720;
 autoMaxContextTokens0[ { ___, "phi3.5"                      , ___ } ] := 2^17;
-autoMaxContextTokens0[ _List                                        ] := 2^12;
+autoMaxContextTokens0[ _List                                        ] := 2^16;
 autoMaxContextTokens0 // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
@@ -1306,7 +1307,7 @@ serviceMaxContextTokens // endDefinition;
 autoMaxTokens // beginDefinition;
 autoMaxTokens[ as_Association ] := autoMaxTokens[ as, as[ "Model" ] ];
 autoMaxTokens[ as_, model_ ] := autoMaxTokens[ as, model, toModelName @ model ];
-autoMaxTokens[ as_, model_, name_String ] := Lookup[ $maxTokensTable, name, Automatic ];
+autoMaxTokens[ as_, model_, name: _String|Automatic ] := Lookup[ $maxTokensTable, name, Automatic ];
 autoMaxTokens // endDefinition;
 
 (* FIXME: this should be something queryable from LLMServices: *)


### PR DESCRIPTION
## Summary

When resolving a service's default model, the code previously fetched the
service's model list eagerly to pick a concrete model name. If that retrieval
failed, the entire resolution failed (see issue #1550).

This PR lets `Automatic` flow through as a model name to be resolved later by
the service connection, rather than forcing a concrete name up front:

- `chooseDefaultModelName` now returns `Automatic` instead of fetching the
  model list, letting the service connection resolve the actual model.
- `toModelName`, `multimodalModelQ`, `autoModelSetting`, `autoMaxContextTokens`,
  `autoMaxTokens`, and `tokenizerName` now accept/preserve `Automatic`, with
  sensible fallbacks (gpt-4o tokenizer, `2^16` context tokens).
- `resolveFullModelSpec` no longer forces a concrete name when the default is
  `Automatic`.
- `getServiceDefaultModel` falls back to the first cached model name when the
  chosen default is `Automatic`.
- `getServiceModelList` no longer caches an empty model list, since an empty
  list usually indicates a retrieval error.

Fixes #1550.

## Test plan

- [ ] `wolframscript -f Scripts/TestPaclet.wls` passes.
- [ ] Select a service whose model list cannot be retrieved (or a freshly
      connected service) and confirm a chat resolves to a working model via
      `Automatic` instead of failing.
- [ ] Confirm the Preferences UI shows a sensible default model for a service
      whose chosen default resolves to `Automatic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)