### PR TITLE
Add triage-failure-reports skill for GitHub issue triage

### DIFF
--- a/.claude/skills/triage-failure-reports/SKILL.md
+++ b/.claude/skills/triage-failure-reports/SKILL.md
@@ -37,7 +37,7 @@ Each report has an auto-generated `<details>` block. The fields that matter:
   Tells you which service/model triggered it.
 - **Failure Data** - the heart of the signature:
   - `"Evaluation"` - the failing call, e.g.
-    `Wolfram`Chatbook`Common`resolveFullModelSpec[<|"Service" -> "OpenAI", "Name" -> Automatic|>]`.
+    ``Wolfram`Chatbook`Common`resolveFullModelSpec[<|"Service" -> "OpenAI", "Name" -> Automatic|>]``.
     The **short function name** (`resolveFullModelSpec`) is the primary key.
   - `"Expression"` - the value that broke a `Confirm*` check, e.g.
     `Missing["NoModelList"]`. (Unhandled-definition failures don't have this

--- a/.claude/skills/triage-failure-reports/SKILL.md
+++ b/.claude/skills/triage-failure-reports/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: triage-failure-reports
+description: >-
+  Triage Chatbook's auto-generated bug-report issues on GitHub by grouping them
+  on their Failure Data signature (the failing Wolfram Language function plus the
+  confirmed expression/pattern), finding the canonical issue or the PR that
+  resolves each cluster, and closing the rest with an explanatory comment. Use
+  this whenever the user wants to dedupe, triage, or clean up GitHub issues - for
+  example "find duplicates of #1550", "are any of these crash reports the same
+  bug?", "close the issues already fixed by PR #906", "triage the open failure
+  reports", or after landing a fix, "which open issues does this close?". It
+  distinguishes true duplicates from look-alikes that fail in a different code
+  path, verifies a candidate fixing PR actually touches the relevant code, and
+  checks each report's Version/ReleaseID against the fix so reports filed on
+  outdated versions are closed correctly and possible regressions are flagged.
+---
+
+# Triage duplicate issues by Failure Data signature
+
+Chatbook posts machine-generated bug reports to GitHub. They pile up because the
+same underlying bug gets reported many times across different services, versions,
+and users. This skill turns that pile into a small number of signature-grouped
+clusters, ties each cluster to the issue or PR that resolves it, and closes the
+duplicates with a comment that tells the reporter where the real fix lives.
+
+The hard part is **not** the closing - it's being sure two reports are actually
+the same bug before you act on someone else's issue. Most of this skill is about
+earning that confidence.
+
+## How a Chatbook failure report is structured
+
+Each report has an auto-generated `<details>` block. The fields that matter:
+
+- **Debug Data table** - `Version` and `ReleaseID` (the git SHA the user was
+  running). These drive the timeline check; do not skip them.
+- **Settings table** - `Model`, e.g. `<|"Service" -> "OpenAI", "Name" -> Automatic|>`.
+  Tells you which service/model triggered it.
+- **Failure Data** - the heart of the signature:
+  - `"Evaluation"` - the failing call, e.g.
+    `Wolfram`Chatbook`Common`resolveFullModelSpec[<|"Service" -> "OpenAI", "Name" -> Automatic|>]`.
+    The **short function name** (`resolveFullModelSpec`) is the primary key.
+  - `"Expression"` - the value that broke a `Confirm*` check, e.g.
+    `Missing["NoModelList"]`. (Unhandled-definition failures don't have this
+    field; the bad value is a call argument instead - see the script's fallback.)
+  - `"Pattern"` - what the value failed to match, e.g. `_List | Missing["NotConnected"]`.
+  - `"Information"` - `Tag@@path:line,col`. Useful for the file; **ignore the
+    line number** - it drifts between versions for the same bug.
+- **Stack Data** - the call stack, e.g. `resolveAutoSettings0 -> EvaluateChatInput`.
+
+### What makes two reports the same bug
+
+Same **failing function** + same **confirmed expression** (and pattern, when
+present). That's it. Everything else is allowed to vary:
+
+- Different **service/model** (OpenAI vs Anthropic vs LocalEvaluator) - same bug.
+- Different **line number** in `Information` - same bug, different version.
+- Different **version/ReleaseID** - same bug reported over time.
+
+The trap to avoid: the *same expression surfacing in a different function* is a
+**sibling bug, not a duplicate**. For example `Missing["NoModelList"]` thrown
+inside `resolveFullModelSpec` (chat evaluation) is a different bug from
+`Missing["NoModelList"]` passed into `makeServiceModelMenu` (the model submenu UI),
+even though both mention `NoModelList`. They get fixed by different PRs. Keyword
+co-occurrence is a candidate filter, never a conclusion.
+
+## Workflow
+
+### 1. Establish the reference signature
+
+If the user named a reference issue, read it (`gh issue view <N>`) and pull the
+failing function + expression + pattern from its Failure Data. If they instead
+handed you a set of reports or a fix, derive the signature from the cluster or
+from the code the fix touches.
+
+### 2. Search broadly for candidates
+
+Search the **distinctive symbols** from the signature - typically the head of the
+expression (`NoModelList`) and the failing function (`resolveFullModelSpec`):
+
+```bash
+gh issue list --state all --search "NoModelList" --json number,title,state
+gh issue list --state all --search "resolveFullModelSpec" --json number,title,state
+```
+
+Two rules that matter:
+
+- **Search `--state all`.** You want closed siblings too: the canonical issue may
+  already be closed, and you must not re-close or miss it.
+- **Use clean alphanumeric tokens.** GitHub's search tokenizer garbles backticks,
+  brackets, and quotes - search `NoModelList`, not `Missing["NoModelList"]`.
+
+Strong candidates appear in **every** term's results (intersection). The helper
+script does this intersection for you.
+
+### 3. Confirm each candidate against the signature
+
+**Do not trust keyword co-occurrence.** Open each candidate's Failure Data and
+verify the failing function and confirmed expression actually match. The helper
+script extracts and groups these for you:
+
+```bash
+# Intersect the searches and print every candidate grouped by signature:
+python .claude/skills/triage-failure-reports/scripts/extract_signatures.py \
+  --search NoModelList --search resolveFullModelSpec
+
+# Or inspect a hand-picked set:
+python .claude/skills/triage-failure-reports/scripts/extract_signatures.py 1550 1545 547
+```
+
+Run it from the repo working directory so `gh` resolves the right repository. It
+prints, per signature group, every issue with its state, version, service,
+created date, and ReleaseID - exactly the columns you need for the next two steps.
+Read `scripts/extract_signatures.py` if you need to adjust parsing for a report
+format it doesn't recognize.
+
+Confirm the groups make sense: the cluster you care about shares one function +
+expression; anything in a different function is a sibling to set aside.
+
+### 4. Identify and verify the resolver
+
+Every cluster needs a single thing it is "resolved by". Two cases:
+
+- **Duplicates of another issue.** Pick the canonical issue - usually the earliest,
+  or the one with the clearest title/discussion. The rest are duplicates of it.
+- **Fixed by a merged PR.** The user may name it ("these are fixed by #906"), or
+  you find it (`gh pr list --search`, or the PR that last touched the failing
+  function). **Verify it - don't take it on faith.** A `#NNNN` can be an issue or a
+  PR (they share one number space), so confirm with `gh pr view <N>`, then check
+  the diff actually addresses this signature:
+
+```bash
+gh pr view 906 --json number,title,state,mergedAt,mergeCommit
+gh pr diff 906 | grep -iE 'makeServiceModelMenu|NoModelList'
+```
+
+You want to see the diff add or change handling for the *failing function* and the
+*expression* (e.g. a new `makeServiceModelMenu[..., Missing["NoModelList"]]`
+definition). If the diff doesn't touch the signature's code path, it is not the fix.
+
+### 5. Verify the timeline - by version, not just date
+
+This is the step that prevents wrong closes. A report can be filed *after* a fix
+merged and still be the old bug, because the user was on a stale paclet. So compare
+the **report's Version/ReleaseID** (from Debug Data) against the fix, not the
+issue's creation date:
+
+- Report version **predates** the fix -> the fix resolves it. Close it.
+- Report version is **newer** than the fix and still shows the signature -> it is
+  **not** resolved (possible regression). Do **not** close as fixed; flag it for a
+  human and keep it open.
+- An issue *created* after the merge but on an *older* version is still fixed - the
+  version is what counts.
+
+For an open canonical issue (not a merged PR), there's no version gate; you're just
+folding duplicates into the one that stays open.
+
+### 6. Close with an explanatory comment
+
+Print the grouped findings first - what will be closed, under which canonical issue
+or PR, and why - so each `gh` write you then make is an informed action. (Closing
+and commenting are irreversible and land on other people's issues; the per-write
+approval is the safety gate, and your verification in steps 3-5 is what makes that
+approval meaningful.)
+
+Comment, then close. Lead the comment with the GitHub-recognized phrasing so the
+link is obvious, and pick the close reason that matches the situation:
+
+| Situation | Comment leads with | Close reason |
+| --- | --- | --- |
+| Duplicate of another issue | `Duplicate of #<canonical>.` | `--reason "not planned"` |
+| Fixed by a merged PR | `Fixed by #<pr>.` | `--reason completed` |
+
+`gh` has no native "duplicate" reason; `not planned` is the honest fit because the
+work is tracked elsewhere. A real merged fix is `completed`.
+
+**Quoting matters.** WL signatures contain backticks, brackets, and quotes that a
+shell will mangle (backticks trigger command substitution). Write the comment to a
+file and use `--body-file`:
+
+```bash
+# comment.md  ->  "Duplicate of #1550 - same `resolveFullModelSpec` failure with
+#                  `Missing[\"NoModelList\"]` ... Fixed by #1558. Closing as a duplicate."
+gh issue comment 1545 --body-file comment.md
+gh issue close   1545 --reason "not planned"
+```
+
+Reuse one comment file across a cluster. Use the scratchpad for fetched bodies and
+comment files. Leave already-closed issues alone (just note them). Leave sibling
+clusters open unless they have their own resolver.
+
+## Worked example
+
+The case this skill was built from:
+
+- Reference **#1550**: `resolveFullModelSpec[<|... "Name" -> Automatic|>]` fails a
+  `ConfirmMatch` with `Missing["NoModelList"]` against `_List | Missing["NotConnected"]`.
+- Searching `NoModelList` x `resolveFullModelSpec` and grouping yielded **8** issues
+  with that exact signature (1086, 1137, 1303, 1468, 1514, 1530, 1545, 1550) across
+  OpenAI/Anthropic/DeepSeek/GoogleGemini/LocalEvaluator - all duplicates, fixed by
+  PR #1558. Closed with `Duplicate of #1550` / `not planned`.
+- Three more (#547, #969, #892) shared `Missing["NoModelList"]` but in
+  `makeServiceModelMenu` - a **sibling**, not a duplicate. Verified PR **#906**
+  added the `makeServiceModelMenu[..., Missing["NoModelList"]]` overload; their
+  versions (1.4.1, 1.4.6, 1.5.2) all predate it, so closed with `Fixed by #906` /
+  `completed`. #969 was *filed* after #906 merged but on old v1.4.6 - the version
+  check, not the date, is what confirmed it.
+
+## Gotchas
+
+- Issues and PRs share one number sequence - confirm which a `#NNNN` is.
+- GitHub search ignores/garbles backticks, brackets, quotes - search symbols.
+- `Information` line numbers drift across versions - never match on them.
+- Verify a claimed fixing PR's diff; "should be fixed by #X" is a hypothesis.
+- Timeline check is by **version/ReleaseID**, not issue creation date.
+- A shared expression in a different function is a sibling bug - close it only
+  under its own resolver, never fold it into the wrong cluster.

--- a/.claude/skills/triage-failure-reports/scripts/extract_signatures.py
+++ b/.claude/skills/triage-failure-reports/scripts/extract_signatures.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+extract_signatures.py - pull the "Failure Data signature" out of Chatbook's
+auto-generated GitHub bug reports so duplicates can be grouped and triaged.
+
+Chatbook crash reports embed a structured block: a failing Wolfram Language
+call ("Evaluation"), the confirmed value that broke a Confirm* check
+("Expression"), the pattern it failed to match ("Pattern"), a file:line
+("Information"), a Stack Data list, plus a Debug Data table with Version and
+ReleaseID. Two reports are the SAME bug when the failing function + confirmed
+expression match - not merely when they share a keyword. This script extracts
+those fields and groups issues by (function, expression) so you can see the
+clusters at a glance.
+
+Usage:
+    # Inspect specific issues:
+    python extract_signatures.py 1550 1545 1530
+
+    # Find candidates by searching (state=all). Each --search runs a separate
+    # `gh issue list` search; an issue must match ALL of them (intersection)
+    # to be included - this is the "take the intersection of term searches"
+    # step done for you:
+    python extract_signatures.py --search NoModelList --search resolveFullModelSpec
+
+    # Combine searches with explicit numbers:
+    python extract_signatures.py --search NoModelList 1086
+
+    # Machine-readable output for further processing:
+    python extract_signatures.py --search NoModelList --json
+
+Options:
+    --search TERM      Repeatable. `gh issue list --state STATE --search TERM`.
+                       Issues must match every --search term to be included.
+    --state STATE      open|closed|all for the searches (default: all).
+    --repo OWNER/NAME  Passed through to gh (otherwise gh infers from cwd).
+    --limit N          Max results per search (default: 200).
+    --json             Emit parsed records as JSON instead of the text report.
+
+Requires: gh (authenticated), Python 3.8+. No third-party dependencies.
+Run it from the repo working directory so gh resolves the right repository.
+"""
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+
+def run_gh(args):
+    """Call gh and return stdout as text; exit cleanly on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args], capture_output=True, text=True, check=True
+        )
+    except FileNotFoundError:
+        sys.exit("error: `gh` not found on PATH. Install/auth the GitHub CLI first.")
+    except subprocess.CalledProcessError as exc:
+        sys.exit(f"error: gh {' '.join(args)}\n{exc.stderr.strip()}")
+    return proc.stdout
+
+
+def search_numbers(term, repo, state, limit):
+    args = ["issue", "list", "--state", state, "--search", term,
+            "--limit", str(limit), "--json", "number"]
+    if repo:
+        args += ["--repo", repo]
+    data = json.loads(run_gh(args) or "[]")
+    return {item["number"] for item in data}
+
+
+def get_issue(number, repo):
+    args = ["issue", "view", str(number), "--json",
+            "number,title,state,createdAt,closedAt,body"]
+    if repo:
+        args += ["--repo", repo]
+    return json.loads(run_gh(args))
+
+
+def _table_value(body, label):
+    """Value from a `| Label | ``...`` |` Debug Data / Settings row. Anchored to
+    end-of-line so values containing `|` (e.g. Model's <|...|>) aren't cut short."""
+    m = re.search(r"^\|\s*" + re.escape(label) + r"\s*\|\s*(.+?)\s*\|\s*$",
+                  body, re.M)
+    if not m:
+        return None
+    # Strip the ``...`` code fence and a surrounding pair of quotes, leaving
+    # `2.6.0` rather than ``"2.6.0"``. Associations like Model start with `<`
+    # so the quote-strip leaves them untouched.
+    return m.group(1).strip().strip("`").strip().strip('"')
+
+
+def _first(body, pattern, flags=re.S):
+    m = re.search(pattern, body, flags)
+    return m.group(1).strip() if m else None
+
+
+# A field key inside the Failure Data association ends the previous value.
+_KEY_END = r'(?:,\s*"\w+"\s*-?[>:]>?|\|>|\n)'
+
+
+def parse_signature(issue):
+    body = issue.get("body") or ""
+
+    version = _table_value(body, "Version")
+    release = _table_value(body, "ReleaseID")
+    model = _table_value(body, "Model")
+    service = None
+    if model:
+        m = re.search(r'"Service"\s*->\s*"([^"]+)"', model)
+        service = m.group(1) if m else None
+
+    # The full failing call. Terminate at the next Failure Data key rather than
+    # on the `|>` of an inline <|...|> association inside the call itself.
+    eval_full = _first(
+        body,
+        r'"Evaluation"\s*:>\s*(.+?),\s*'
+        r'"(?:Information|ConfirmationType|Pattern|Failure|Stack|Arguments)"',
+    )
+    if not eval_full:  # Evaluation is the last key in the block
+        eval_full = _first(body, r'"Evaluation"\s*:>\s*(.+)', flags=0)
+    function = eval_full.split("[", 1)[0].split("`")[-1].strip() if eval_full else None
+
+    # Confirm* failures record the bad value as "Expression". Unhandled-definition
+    # failures (e.g. the model submenu) instead pass it as a call argument, so
+    # fall back to the first Missing[...] inside the call. Sharing a bad value
+    # across *different* functions means sibling bugs, not duplicates.
+    expression = _first(body, r'"Expression"\s*:>\s*(.+?)\s*' + _KEY_END)
+    if not expression and eval_full:
+        m = re.search(r'Missing\[\s*"[^"]+"\s*\]', eval_full)
+        expression = m.group(0) if m else None
+    pattern = _first(body, r'"Pattern"\s*->\s*(.+?)\s*' + _KEY_END)
+
+    info = _first(body, r'"Information"\s*->\s*"([^"]+)"')
+    info_file, info_loc = None, None
+    if info:
+        # e.g. Models@@Source/Chatbook/Models.wl:845,18-845,108
+        tail = info.split("@@", 1)[-1]
+        if ":" in tail:
+            info_file, info_loc = tail.split(":", 1)
+        else:
+            info_file = tail
+
+    stack_block = _first(body, r"##\s*Stack Data\s*`{3,}\s*(.*?)`{3,}")
+    stack = []
+    if stack_block:
+        stack = [ln.strip() for ln in stack_block.splitlines() if ln.strip()]
+
+    return {
+        "number": issue.get("number"),
+        "title": issue.get("title"),
+        "state": issue.get("state"),
+        "createdAt": issue.get("createdAt"),
+        "closedAt": issue.get("closedAt"),
+        "version": version,
+        "releaseID": release,
+        "service": service,
+        "function": function,
+        "expression": expression,
+        "pattern": pattern,
+        "infoFile": info_file,
+        "infoLoc": info_loc,
+        "stack": stack,
+    }
+
+
+def signature_key(rec):
+    return (rec["function"] or "?", rec["expression"] or "?")
+
+
+def print_report(records):
+    groups = {}
+    for rec in records:
+        groups.setdefault(signature_key(rec), []).append(rec)
+
+    # Largest clusters first; they're the most likely duplicate sets.
+    for key, recs in sorted(groups.items(), key=lambda kv: -len(kv[1])):
+        function, expression = key
+        print("=" * 78)
+        print(f"SIGNATURE  function={function}  expression={expression}")
+        print(f"           pattern={recs[0]['pattern']}")
+        print(f"           file={recs[0]['infoFile']}  ({len(recs)} issue(s))")
+        print(f"           stack-top={' -> '.join(recs[0]['stack'][-3:]) or '?'}")
+        print("-" * 78)
+        for r in sorted(recs, key=lambda r: r["number"]):
+            flag = "  [CLOSED]" if r["state"] == "CLOSED" else ""
+            print(f"  #{r['number']:<6} {r['state']:<6} v{r['version'] or '?':<8} "
+                  f"{r['service'] or '?':<14} {(r['title'] or '')[:46]}{flag}")
+            print(f"          created={r['createdAt']}  release={r['releaseID']}")
+        print()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("numbers", nargs="*", type=int, help="issue numbers")
+    ap.add_argument("--search", action="append", default=[], metavar="TERM")
+    ap.add_argument("--state", default="all", choices=["open", "closed", "all"])
+    ap.add_argument("--repo", default=None)
+    ap.add_argument("--limit", type=int, default=200)
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    args = ap.parse_args()
+
+    candidates = set(args.numbers)
+    if args.search:
+        sets = [search_numbers(t, args.repo, args.state, args.limit) for t in args.search]
+        intersection = set.intersection(*sets) if sets else set()
+        candidates |= intersection
+        for term, s in zip(args.search, sets):
+            print(f"# search {term!r}: {len(s)} hits", file=sys.stderr)
+        print(f"# intersection of searches: {sorted(intersection)}", file=sys.stderr)
+
+    if not candidates:
+        sys.exit("No issues to inspect. Pass issue numbers and/or --search terms.")
+
+    records = [parse_signature(get_issue(n, args.repo)) for n in sorted(candidates)]
+
+    if args.as_json:
+        print(json.dumps(records, indent=2))
+    else:
+        print_report(records)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a project-level Claude Code skill, `triage-failure-reports`, that triages
Chatbook's auto-generated bug-report issues on GitHub.

Chatbook posts machine-generated crash reports that pile up because the same
underlying bug gets reported many times across different services, versions, and
users. The skill turns that pile into a few signature-grouped clusters and ties
each to its resolver:

- **Groups reports by Failure Data signature** — the failing Wolfram Language
  function plus the confirmed expression/pattern — rather than by keyword.
- **Distinguishes true duplicates from look-alikes** that surface the same value
  in a *different* code path (sibling bugs, not duplicates).
- **Verifies the resolver**: confirms a candidate fixing PR's diff actually
  touches the signature's code, and checks each report's `Version`/`ReleaseID`
  against the fix so reports filed on outdated versions are closed correctly and
  possible regressions are flagged.
- **Closes with an explanatory comment** using the appropriate close reason
  (`not planned` for duplicates, `completed` for fixed-by-PR).

### Files

- `.claude/skills/triage-failure-reports/SKILL.md` — the workflow.
- `.claude/skills/triage-failure-reports/scripts/extract_signatures.py` — a helper
  that intersects `gh` issue searches and prints each candidate grouped by
  signature with its state, version, service, and ReleaseID (no third-party deps).

This captures a workflow that was just run by hand: triaging the `resolveFullModelSpec`
/ `Missing["NoModelList"]` cluster (8 duplicates of #1550, fixed by #1558) and the
sibling `makeServiceModelMenu` reports (#547/#969, fixed by #906).

## Test plan

- [ ] `python .claude/skills/triage-failure-reports/scripts/extract_signatures.py --search NoModelList --search resolveFullModelSpec` reproduces the 8-issue `resolveFullModelSpec` cluster, grouped under one signature with correct version/service/release columns. *(verified)*
- [ ] The same script on a mixed set (e.g. `1550 547`) separates the `resolveFullModelSpec` and `makeServiceModelMenu` signatures into distinct groups. *(verified)*
- [ ] In a fresh session, a prompt like "find duplicates of #<n>" or "are any of these crash reports the same bug?" triggers the skill.
- [ ] `settings.local.json` remains gitignored and is not included in this PR.

## Notes

No code in the paclet itself is changed; this only adds tooling under `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)