### PR TITLE
Fix appendCitations failure when $sources is None (#1393)

### DIFF
--- a/Source/Chatbook/Citations.wl
+++ b/Source/Chatbook/Citations.wl
@@ -300,9 +300,9 @@ appendCitations // Attributes = { HoldFirst };
 
 appendCitations[ container_, settings_ ] := Enclose[
     Catch @ Module[ { sources, citations },
-        sources = Values @ ConfirmBy[ $sources, AssociationQ, "Sources" ];
-        applyHandlerFunction[ settings, "AppendCitationsStart", "Sources" -> sources ];
         If[ ! TrueQ @ settings[ "AppendCitations" ], Throw @ Null ];
+        sources = Values @ Replace[ $sources, Except[ _? AssociationQ ] :> <| |> ];
+        applyHandlerFunction[ settings, "AppendCitationsStart", "Sources" -> sources ];
         citations = ConfirmBy[ makeCitationsString[ container[ "FullContent" ], sources ], StringQ, "Citations" ];
         container[ "FullContent" ] = container[ "FullContent" ] <> citations;
         container[ "DynamicContent" ] = container[ "DynamicContent" ] <> citations;

--- a/Tests/Citations.wlt
+++ b/Tests/Citations.wlt
@@ -1,0 +1,65 @@
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`ChatbookTests`", FileNameJoin @ { DirectoryName[ $TestFileName ], "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/Citations.wlt:4,1-9,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`Chatbook`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/Citations.wlt:11,1-16,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*appendCitations*)
+
+(* Regression tests for issue #1393: appendCitations can run after the withChatState Block
+   has unwound (e.g. from an async FE task), at which point Wolfram`Chatbook`Common`$sources
+   has reverted to its global default of None. It must not fail the AssociationQ confirmation
+   in that state, regardless of the "AppendCitations" setting. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*$sources is None and citations are disabled*)
+VerificationTest[
+    Block[ { Wolfram`Chatbook`Common`$sources = None },
+        Module[ { container, result },
+            container = <| "FullContent" -> "Hello world.", "DynamicContent" -> "Hello world." |>;
+            result = Wolfram`Chatbook`Common`appendCitations[ container, <| "AppendCitations" -> False |> ];
+            { FailureQ @ result, container[ "FullContent" ], container[ "DynamicContent" ] }
+        ]
+    ],
+    { False, "Hello world.", "Hello world." },
+    TestID -> "appendCitations-NoneSources-Disabled@@Tests/Citations.wlt:30,1-40,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*$sources is None and citations are enabled*)
+VerificationTest[
+    Block[ { Wolfram`Chatbook`Common`$sources = None },
+        Module[ { container, result },
+            container = <| "FullContent" -> "Hello world.", "DynamicContent" -> "Hello world." |>;
+            result = Wolfram`Chatbook`Common`appendCitations[
+                container,
+                <|
+                    "AppendCitations"  -> True,
+                    "HandlerFunctions" -> <|
+                        "Resolved"             -> True,
+                        "AppendCitationsStart" -> (Null &),
+                        "AppendCitationsEnd"   -> (Null &)
+                    |>
+                |>
+            ];
+            { FailureQ @ result, container[ "FullContent" ], container[ "DynamicContent" ] }
+        ]
+    ],
+    { False, "Hello world.", "Hello world." },
+    TestID -> "appendCitations-NoneSources-Enabled@@Tests/Citations.wlt:45,1-65,2"
+]


### PR DESCRIPTION
## Summary

Fixes #1393.

`appendCitations` could run after the `withChatState` `Block` had unwound (e.g. from an async FrontEnd task), at which point ``Wolfram`Chatbook`Common`$sources`` has reverted to its global default of `None`. The `ConfirmBy[ $sources, AssociationQ, "Sources" ]` then failed with a `ConfirmationFailed` error — the "pink" reported in the issue. This happens regardless of the `"AppendCitations"` setting (the report had it `False`).

Note that `$sources` is only ever `None` *outside* the `withChatState` scope — inside it, it is at minimum `<||>` (which passes `AssociationQ`). So the failure is specifically a scope-escape, and "no sources" is the correct interpretation in that state.

## Changes

- **`Source/Chatbook/Citations.wl`** — in `appendCitations`:
  - Read `$sources` defensively: `Values @ Replace[ $sources, Except[ _? AssociationQ ] :> <| |> ]` instead of confirming it with `ConfirmBy[ …, AssociationQ ]`. This mirrors the defensiveness already present in `addToSources`, and covers both `AppendCitations -> True` and `False`.
  - Move the `AppendCitations` early-return above the source handling so the `"AppendCitationsStart"` handler only fires when citations are actually enabled — matching `"AppendCitationsEnd"`, which was already gated.
- **`Tests/Citations.wlt`** (new) — regression tests calling `appendCitations` with ``Wolfram`Chatbook`Common`$sources = None`` for both `AppendCitations -> True` and `False`, asserting no `Failure` and an untouched container.

## Test plan

- [x] `Tests/Citations.wlt` passes with the fix (4/4).
- [x] Confirmed the tests **fail** against the pre-fix code, reproducing the exact issue #1393 signature (`Failure["ConfirmationFailed", … "ConfirmationType" -> "ConfirmBy", "Function" -> AssociationQ, "Information" -> "Sources"]`).
- [x] `CodeInspector` reports no issues on `Source/Chatbook/Citations.wl`.
- The enabled-path test stays fully offline: with empty sources, `generateCitations` returns early at the `shortIDs === {}` check before any `llmSynthesize` call, so no model is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)