### PR TITLE
Mitigate crashes from `CreateUUID[]` failures with a `createUUID` fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .mcp.json
 .obsidian/
 *StackHistory.wxf
+bash.exe.stackdump
 Assets/Snippets/Streamable/*
 Assets/VectorDatabases/**/*.usearch
 Assets/VectorDatabases/**/*.wl

--- a/Scripts/BuildPaclet.wls
+++ b/Scripts/BuildPaclet.wls
@@ -47,7 +47,6 @@ If[ $download,
         GeneralUtilities`EnsureDirectory @ DirectoryName @ targetDir;
         cicd`ConsoleLog @ SequenceForm[ "Copying documentation snippets from ", snippetDir, " to ", targetDir ];
         copied = cDir @ CopyDirectory[ snippetDir, targetDir ];
-        cicd`ConsoleLog @ SequenceForm[ "Copied documentation snippets from ", snippetDir, " to ", copied ];
         If[ StringQ @ Environment[ "GITHUB_ACTIONS" ], DeleteDirectory[ snippetDir, DeleteContents -> True ] ];
     ]
 ];

--- a/Scripts/BuildPaclet.wls
+++ b/Scripts/BuildPaclet.wls
@@ -41,12 +41,13 @@ Needs[ "Wolfram`PacletCICD`" -> "cicd`" ];
 If[ $download,
     Block[ { $ProgressReporting = True },
         cicd`ConsoleLog[ "Downloading documentation snippets..." ];
-        snippetDir = cDir @ Wolfram`Chatbook`InstallDocumentationResources[ ][ "Location" ];
         targetDir = FileNameJoin @ { $pacletDir, "Assets/Snippets/Streamable" };
         If[ DirectoryQ @ targetDir, DeleteDirectory[ targetDir, DeleteContents -> True ] ];
+        snippetDir = cDir @ Wolfram`Chatbook`InstallDocumentationResources[ ][ "Location" ];
         GeneralUtilities`EnsureDirectory @ DirectoryName @ targetDir;
+        cicd`ConsoleLog @ SequenceForm[ "Copying documentation snippets from ", snippetDir, " to ", targetDir ];
         copied = cDir @ CopyDirectory[ snippetDir, targetDir ];
-        cicd`ConsoleLog @ SequenceForm[ "Copied documentation snippets to: ", copied ];
+        cicd`ConsoleLog @ SequenceForm[ "Copied documentation snippets from ", snippetDir, " to ", copied ];
         If[ StringQ @ Environment[ "GITHUB_ACTIONS" ], DeleteDirectory[ snippetDir, DeleteContents -> True ] ];
     ]
 ];

--- a/Source/Chatbook/Actions.wl
+++ b/Source/Chatbook/Actions.wl
@@ -60,50 +60,61 @@ ChatCellEvaluate[ args___ ] :=
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*ChatbookAction*)
-ChatbookAction[ "AccentIncludedCells"          , args___ ] := catchMine @ accentIncludedCells @ args;
-ChatbookAction[ "AIAutoAssist"                 , args___ ] := catchMine @ AIAutoAssist @ args;
-ChatbookAction[ "Ask"                          , args___ ] := catchMine @ AskChat @ args;
-ChatbookAction[ "AssistantMessageLabel"        , args___ ] := catchMine @ assistantMessageLabel @ args;
-ChatbookAction[ "AttachAssistantMessageButtons", args___ ] := catchMine @ attachAssistantMessageButtons @ args;
-ChatbookAction[ "AttachCodeButtons"            , args___ ] := catchMine @ AttachCodeButtons @ args;
-ChatbookAction[ "AttachWorkspaceChatInput"     , args___ ] := catchMine @ attachWorkspaceChatInput @ args;
-ChatbookAction[ "CopyChatObject"               , args___ ] := catchMine @ CopyChatObject @ args;
-ChatbookAction[ "CopyExplodedCells"            , args___ ] := catchMine @ CopyExplodedCells @ args;
-ChatbookAction[ "CopyImage"                    , args___ ] := catchMine @ copyImage @ args;
-ChatbookAction[ "CopyPlainText"                , args___ ] := catchMine @ copyPlainText @ args;
-ChatbookAction[ "DisableAssistance"            , args___ ] := catchMine @ DisableAssistance @ args;
-ChatbookAction[ "DisplayInlineChat"            , args___ ] := catchMine @ displayInlineChat @ args;
-ChatbookAction[ "EvaluateChatInput"            , args___ ] := catchMine @ EvaluateChatInput @ args;
-ChatbookAction[ "EvaluateInlineChat"           , args___ ] := catchMine @ evaluateInlineChat @ args;
-ChatbookAction[ "EvaluateSidebarChat"          , args___ ] := catchMine @ evaluateSidebarChat @ args;
-ChatbookAction[ "EvaluateWorkspaceChat"        , args___ ] := catchMine @ evaluateWorkspaceChat @ args;
-ChatbookAction[ "ExclusionToggle"              , args___ ] := catchMine @ ExclusionToggle @ args;
-ChatbookAction[ "ExplodeDuplicate"             , args___ ] := catchMine @ ExplodeDuplicate @ args;
-ChatbookAction[ "ExplodeInPlace"               , args___ ] := catchMine @ ExplodeInPlace @ args;
-ChatbookAction[ "InsertCodeBelow"              , args___ ] := catchMine @ insertCodeBelow @ args;
-ChatbookAction[ "InsertInlineReference"        , args___ ] := catchMine @ InsertInlineReference @ args;
-ChatbookAction[ "MakeChatbarChatInputCellContent" , args___ ] := catchMine @ makeChatbarChatInputCellContent @ args;
-ChatbookAction[ "MakeSidebarChatDockedCell"    , args___ ] := catchMine @ makeSidebarChatDockedCell @ args;
-ChatbookAction[ "MakeSidebarChatInputCell"     , args___ ] := catchMine @ makeSidebarChatInputCell @ args;
-ChatbookAction[ "MakeSidebarChatScrollingCell" , args___ ] := catchMine @ makeSidebarChatScrollingCell @ args;
-ChatbookAction[ "MakeWorkspaceChatDockedCell"  , args___ ] := catchMine @ makeWorkspaceChatDockedCell @ args;
-ChatbookAction[ "MoveToChatInputField"         , args___ ] := catchMine @ moveToChatInputField @ args;
-ChatbookAction[ "OpenChatBlockSettings"        , args___ ] := catchMine @ OpenChatBlockSettings @ args;
-ChatbookAction[ "OpenChatMenu"                 , args___ ] := catchMine @ OpenChatMenu @ args;
-ChatbookAction[ "PersonaManage"                , args___ ] := catchMine @ PersonaManage @ args;
-ChatbookAction[ "RegenerateAssistantMessage"   , args___ ] := catchMine @ regenerateAssistantMessage @ args;
-ChatbookAction[ "RemoveCellAccents"            , args___ ] := catchMine @ removeCellAccents @ args;
-ChatbookAction[ "Send"                         , args___ ] := catchMine @ SendChat @ args;
-ChatbookAction[ "SendFeedback"                 , args___ ] := catchMine @ SendFeedback @ args;
-ChatbookAction[ "StopChat"                     , args___ ] := catchMine @ StopChat @ args;
-ChatbookAction[ "TabLeft"                      , args___ ] := catchMine @ TabLeft @ args;
-ChatbookAction[ "TabRight"                     , args___ ] := catchMine @ TabRight @ args;
-ChatbookAction[ "ToggleFormatting"             , args___ ] := catchMine @ ToggleFormatting @ args;
-ChatbookAction[ "ToolManage"                   , args___ ] := catchMine @ ToolManage @ args;
-ChatbookAction[ "UpdateDynamics"               , args___ ] := catchMine @ updateDynamics @ args;
-ChatbookAction[ "UserMessageLabel"             , args___ ] := catchMine @ userMessageLabel @ args;
-ChatbookAction[ "WidgetSend"                   , args___ ] := catchMine @ WidgetSend @ args;
-ChatbookAction[ args___                                  ] := catchMine @ throwInternalFailure @ ChatbookAction @ args;
+ChatbookAction // beginDefinition;
+
+ChatbookAction[ name_String, args___ ] := catchMine @ LogChatTiming[
+    chatbookAction[ name, args ],
+    "ChatbookAction:" <> name
+];
+
+ChatbookAction // endExportedDefinition;
+
+
+chatbookAction // beginDefinition;
+chatbookAction[ "AccentIncludedCells"             , args___ ] := accentIncludedCells @ args;
+chatbookAction[ "AIAutoAssist"                    , args___ ] := AIAutoAssist @ args;
+chatbookAction[ "Ask"                             , args___ ] := AskChat @ args;
+chatbookAction[ "AssistantMessageLabel"           , args___ ] := assistantMessageLabel @ args;
+chatbookAction[ "AttachAssistantMessageButtons"   , args___ ] := attachAssistantMessageButtons @ args;
+chatbookAction[ "AttachCodeButtons"               , args___ ] := AttachCodeButtons @ args;
+chatbookAction[ "AttachWorkspaceChatInput"        , args___ ] := attachWorkspaceChatInput @ args;
+chatbookAction[ "CopyChatObject"                  , args___ ] := CopyChatObject @ args;
+chatbookAction[ "CopyExplodedCells"               , args___ ] := CopyExplodedCells @ args;
+chatbookAction[ "CopyImage"                       , args___ ] := copyImage @ args;
+chatbookAction[ "CopyPlainText"                   , args___ ] := copyPlainText @ args;
+chatbookAction[ "DisableAssistance"               , args___ ] := DisableAssistance @ args;
+chatbookAction[ "DisplayInlineChat"               , args___ ] := displayInlineChat @ args;
+chatbookAction[ "EvaluateChatInput"               , args___ ] := EvaluateChatInput @ args;
+chatbookAction[ "EvaluateInlineChat"              , args___ ] := evaluateInlineChat @ args;
+chatbookAction[ "EvaluateSidebarChat"             , args___ ] := evaluateSidebarChat @ args;
+chatbookAction[ "EvaluateWorkspaceChat"           , args___ ] := evaluateWorkspaceChat @ args;
+chatbookAction[ "ExclusionToggle"                 , args___ ] := ExclusionToggle @ args;
+chatbookAction[ "ExplodeDuplicate"                , args___ ] := ExplodeDuplicate @ args;
+chatbookAction[ "ExplodeInPlace"                  , args___ ] := ExplodeInPlace @ args;
+chatbookAction[ "InsertCodeBelow"                 , args___ ] := insertCodeBelow @ args;
+chatbookAction[ "InsertInlineReference"           , args___ ] := InsertInlineReference @ args;
+chatbookAction[ "MakeChatbarChatInputCellContent" , args___ ] := makeChatbarChatInputCellContent @ args;
+chatbookAction[ "MakeSidebarChatDockedCell"       , args___ ] := makeSidebarChatDockedCell @ args;
+chatbookAction[ "MakeSidebarChatInputCell"        , args___ ] := makeSidebarChatInputCell @ args;
+chatbookAction[ "MakeSidebarChatScrollingCell"    , args___ ] := makeSidebarChatScrollingCell @ args;
+chatbookAction[ "MakeWorkspaceChatDockedCell"     , args___ ] := makeWorkspaceChatDockedCell @ args;
+chatbookAction[ "MoveToChatInputField"            , args___ ] := moveToChatInputField @ args;
+chatbookAction[ "OpenChatBlockSettings"           , args___ ] := OpenChatBlockSettings @ args;
+chatbookAction[ "OpenChatMenu"                    , args___ ] := OpenChatMenu @ args;
+chatbookAction[ "PersonaManage"                   , args___ ] := PersonaManage @ args;
+chatbookAction[ "RegenerateAssistantMessage"      , args___ ] := regenerateAssistantMessage @ args;
+chatbookAction[ "RemoveCellAccents"               , args___ ] := removeCellAccents @ args;
+chatbookAction[ "Send"                            , args___ ] := SendChat @ args;
+chatbookAction[ "SendFeedback"                    , args___ ] := SendFeedback @ args;
+chatbookAction[ "StopChat"                        , args___ ] := StopChat @ args;
+chatbookAction[ "TabLeft"                         , args___ ] := TabLeft @ args;
+chatbookAction[ "TabRight"                        , args___ ] := TabRight @ args;
+chatbookAction[ "ToggleFormatting"                , args___ ] := ToggleFormatting @ args;
+chatbookAction[ "ToolManage"                      , args___ ] := ToolManage @ args;
+chatbookAction[ "UpdateDynamics"                  , args___ ] := updateDynamics @ args;
+chatbookAction[ "UserMessageLabel"                , args___ ] := userMessageLabel @ args;
+chatbookAction[ "WidgetSend"                      , args___ ] := WidgetSend @ args;
+chatbookAction // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -114,7 +125,7 @@ regenerateAssistantMessage[ chatOutput_CellObject, True(*sidebarCellQ_*) ] := En
     Catch @ Module[ { chatInputCell, sidebarCell, chatInputFieldCell },
         chatInputCell = PreviousCell[ chatOutput, CellStyle -> "NotebookAssistant`Sidebar`ChatInput" ];
         If[ ! MatchQ[ chatInputCell, _CellObject ], Throw @ Null ];
-        
+
         sidebarCell = ConfirmMatch[ ParentCell @ ParentCell @ chatOutput, _CellObject, "SidebarCell" ];
         chatInputFieldCell = ConfirmMatch[ Last[ Cells[ sidebarCell, CellTags -> "SidebarChatInputCell" ], None ], _CellObject, "SidebarChatInputFieldCell" ];
 

--- a/Source/Chatbook/ChatModes/Evaluate.wl
+++ b/Source/Chatbook/ChatModes/Evaluate.wl
@@ -31,7 +31,7 @@ evaluateWorkspaceChat[ nbo_NotebookObject, Dynamic[ input: _Symbol|_CurrentValue
 
         If[ ! validInputStringQ @ input, input = ""; Throw @ Null ];
         text = makeBoxesInputMoreTextLike @ input;
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
 
         cell = Cell[
             BoxData @ TemplateBox[
@@ -98,7 +98,7 @@ evaluateSidebarChat[ nbo_NotebookObject, sidebarCell_CellObject, input_, Dynamic
     Module[ { text, uuid, cell },
 
         text = makeBoxesInputMoreTextLike @ input;
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
 
         cell = Cell[
             BoxData @ TemplateBox[
@@ -108,7 +108,7 @@ evaluateSidebarChat[ nbo_NotebookObject, sidebarCell_CellObject, input_, Dynamic
             "NotebookAssistant`Sidebar`ChatInput",
             (* If we were writing this CellObject as a top-level cell then we could use ExpressoinUUID to coerce the front end use a pre-specified UUID.
                 However, the side bar is a more complicated Cell within a Cell and in that case the ExpressoinUUID is dropped. *)
-            CellTags -> uuid 
+            CellTags -> uuid
         ];
 
         cellObject = appendCellToSidebarChat[ nbo, sidebarCell, cell, uuid ];
@@ -129,7 +129,7 @@ evaluateChatbarChat[ nbo_NotebookObject, anchor:_CellObject | None, selectionAtT
 
         cellObject = None;
         text = makeBoxesInputMoreTextLike @ input;
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
 
         cellExpr = Cell[ text, "ChatInput", CellTags -> uuid ];
 
@@ -143,7 +143,7 @@ evaluateChatbarChat[ nbo_NotebookObject, anchor:_CellObject | None, selectionAtT
         cellObject = First[ Cells[ nbo, CellTags -> uuid, CellStyle -> "ChatInput" ], Missing[ "CellNotAvailable" ] ];
         ConfirmMatch[ cellObject, _CellObject, "FooterChatInputCellObject" ];
         setCurrentValue[ cellObject, CellTags, Inherited ];
-        
+
         ConfirmMatch[ ChatCellEvaluate[ cellObject, nbo ], _ChatObject|Null, "ChatCellEvaluate" ]
     ],
     throwInternalFailure

--- a/Source/Chatbook/ChatModes/ShowNotebookAssistance.wl
+++ b/Source/Chatbook/ChatModes/ShowNotebookAssistance.wl
@@ -34,7 +34,7 @@ $notebookAssistanceWorkspaceSettings := <|
     $notebookAssistanceBaseSettings,
     "AutoGenerateTitle"     -> True,
     "AutoSaveConversations" -> True,
-    "ConversationUUID"      -> CreateUUID[ ],
+    "ConversationUUID"      -> createUUID[ ],
     "SetCellDingbat"        -> False,
     "TabbedOutput"          -> False,
     "WorkspaceChat"         -> True
@@ -56,7 +56,7 @@ $notebookAssistanceSidebarSettings := <|
     "AllowSelectionContext" -> False,
     "AutoGenerateTitle"     -> True,
     "AutoSaveConversations" -> True,
-    "ConversationUUID"      -> CreateUUID[ ],
+    "ConversationUUID"      -> createUUID[ ],
     "SetCellDingbat"        -> False,
     "TabbedOutput"          -> False,
     "SidebarChat"           -> True
@@ -413,7 +413,7 @@ autoShowNotebookAssistance // beginDefinition;
 autoShowNotebookAssistance[ "CellInsertionPoint", obj0_, opts: OptionsPattern[ ] ] /; sufficientVersionQ[ 15.0 ] := Enclose[
     Catch @ Module[ { nbo, newCell, uuid, sidebarInfo, sidebarCell, cellObject },
         nbo = ConfirmMatch[ EvaluationNotebook[ ], _NotebookObject, "Notebook" ];
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
 
         sidebarInfo = ConfirmMatch[ With[ { nb = nbo }, FE`Evaluate @ FEPrivate`SidebarExtensionInformation[ nb, "NotebookAssistant" ] ], _Association|None, "SidebarInfo" ];
 
@@ -455,7 +455,7 @@ autoShowNotebookAssistance[ "CellInsertionPoint", obj0_, opts: OptionsPattern[ ]
                     },
                     If[ ! MissingQ @ scrollablePaneCell, NotebookDelete /@ Cells[ scrollablePaneCell ] ];
                 ];
-                CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = CreateUUID[ ];
+                CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = createUUID[ ];
                 setCurrentValue[ sidebarCell, { TaggingRules, "ConversationTitle" }, "" ];
                 cellObject = appendCellToSidebarChat[ nbo, sidebarCell, newCell, uuid ];
                 ConfirmMatch[ ChatCellEvaluate[ cellObject, nbo ], _ChatObject|Null, "ChatCellEvaluate" ]

--- a/Source/Chatbook/ChatModes/UI.wl
+++ b/Source/Chatbook/ChatModes/UI.wl
@@ -407,7 +407,7 @@ sidebarNewChatButton[ nbo_, sidebarCell_ ] :=
         NotebookDelete @ Cells[ nbo, CellStyle -> "AttachedOverlayMenu", AttachedCell -> True ];
         removeSidebarScrollingCellContent[ nbo, sidebarCell ];
         removeSidebarChatSubDockedCell[ nbo, sidebarCell ];
-        CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = CreateUUID[ ];
+        CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = createUUID[ ];
         setCurrentValue[ sidebarCell, { TaggingRules, "ConversationTitle" }, "" ]
         ,
         Appearance -> "Suppressed",
@@ -464,7 +464,7 @@ sidebarOpenAsAssistantWindowButton[ nbo_, sidebarCell_ ] := Button[
             NotebookDelete @ Cells[ nbo, CellStyle -> "AttachedOverlayMenu", AttachedCell -> True ];
             removeSidebarScrollingCellContent[ nbo, sidebarCell ];
             removeSidebarChatSubDockedCell[ nbo, sidebarCell ];
-            CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = CreateUUID[ ];
+            CurrentChatSettings[ sidebarCell, "ConversationUUID" ] = createUUID[ ];
             setCurrentValue[ sidebarCell, { TaggingRules, "ConversationTitle" }, "" ];
             FrontEndTokenExecute[ nbo, "HideSidebar" ];
         ]
@@ -2273,7 +2273,7 @@ chatbarWriteAndEvaluateChatInputCell[ nbo_NotebookObject, chatbarCell_CellObject
 
         cellObject = None;
         text = makeBoxesInputMoreTextLike @ input;
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
 
         cellExpr = Cell[ text, "ChatInput",
             CellTags -> uuid,
@@ -2563,7 +2563,7 @@ newChatButton[ nbo_NotebookObject ] :=
         clearOverlayMenus @ nbo;
         NotebookDelete @ Cells @ nbo;
         removeWorkspaceChatSubDockedCell @ nbo;
-        CurrentChatSettings[ nbo, "ConversationUUID" ] = CreateUUID[ ];
+        CurrentChatSettings[ nbo, "ConversationUUID" ] = createUUID[ ];
         setCurrentValue[ nbo, { TaggingRules, "ConversationTitle" }, "" ];
         moveChatInputToTop @ nbo;
         ,

--- a/Source/Chatbook/CloudToolbar.wl
+++ b/Source/Chatbook/CloudToolbar.wl
@@ -307,7 +307,7 @@ insertCellStyle[ style_String ] :=
 
 insertCellStyle[ style_String, nbo_NotebookObject ] := Enclose[
     Module[ { tag, cell, cellObject },
-        tag = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        tag = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
         cell = Cell[ "", style, CellTags -> tag ];
         SelectionMove[ nbo, After, Cell ]; (* prevents inline cells *)
         NotebookWrite[ nbo, cell ];

--- a/Source/Chatbook/Common.wl
+++ b/Source/Chatbook/Common.wl
@@ -612,7 +612,7 @@ catchTop[ eval_ ] := catchTop[ eval, Chatbook ];
 catchTop[ eval_, sym_Symbol ] :=
     Block[
         {
-            $chatEvaluationID    = CreateUUID[ ],
+            $chatEvaluationID    = createUUID[ ],
             $currentChatSettings = None,
             $messageSymbol       = Replace[ $messageSymbol, Chatbook -> sym ],
             $catching            = True,

--- a/Source/Chatbook/CommonSymbols.wl
+++ b/Source/Chatbook/CommonSymbols.wl
@@ -167,6 +167,7 @@ BeginPackage[ "Wolfram`Chatbook`Common`" ];
 `createMenuService;
 `createNewInlineOutput;
 `createPreferencesContent;
+`createUUID;
 `currentChatSettings;
 `cv;
 `cvExpand;

--- a/Source/Chatbook/FrontEnd.wl
+++ b/Source/Chatbook/FrontEnd.wl
@@ -666,7 +666,7 @@ Module[ { cellStack, cellInformation, cellStyles },
     cellStack       = Prepend[ cellStack, cell ]; (* just in case we used topParentCell on a sidebar top-level cell *)
     cellInformation = Developer`CellInformation @ cellStack;
     cellStyles      = Lookup[ #, "Style", { }, Flatten[ { # } ]& ]& /@ cellInformation;
-    
+
     If[ MemberQ[ Last @ cellStyles, "NotebookAssistant`Sidebar`NotebookAssistantSidebarCell" ],
         First[
             Pick[ cellStack, MemberQ[ #, "NotebookAssistant`Sidebar`ChatOutput" | "NotebookAssistant`Sidebar`ChatInput" ]& /@ cellStyles ],
@@ -702,7 +702,7 @@ cloudCellPrint[ cell_Cell ] :=
 
 cloudCellPrint[ Cell[ a__, CellTags -> tags0_, b___ ] ] := Enclose[
     Module[ { uuid, tags, cell, obj },
-        uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+        uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
         tags = Select[ Flatten @ { tags0, uuid }, StringQ ];
         cell = Cell[ a, CellTags -> tags, b ];
         CellPrint @ cell;
@@ -738,7 +738,7 @@ cellPrintAfter[ target_CellObject, cell: Cell[ __, ExpressionUUID -> uuid_, ___ 
 );
 
 cellPrintAfter[ target_CellObject, cell_Cell ] :=
-    cellPrintAfter[ target, Append[ cell, ExpressionUUID -> CreateUUID[ ] ] ];
+    cellPrintAfter[ target, Append[ cell, ExpressionUUID -> createUUID[ ] ] ];
 
 cellPrintAfter[ a_, b__ ] := throwInternalFailure @ cellPrintAfter[ a, b ];
 cellPrintAfter[ a_ ][ b___ ] := throwInternalFailure @ cellPrintAfter[ a ][ b ];
@@ -1309,7 +1309,7 @@ $statelessProgressIndicator =
 (* ::Subsection::Closed:: *)
 (*CurrentValue*)
 
-(* CurrentValue[...] = value actually calls CurrentValue twice, requiring two MathLink transactions. 
+(* CurrentValue[...] = value actually calls CurrentValue twice, requiring two MathLink transactions.
     If we only want to set the value and are not using the returned value then only make one MathLink call. *)
 setCurrentValue[ args__, value_ ] := (CurrentValue[ args ] = value) /; value === Inherited  (* Inherited may return values other than Inherited, so don't use a single MathLink call *)
 setCurrentValue[ args__, value_ ] := (CurrentValue[ args ] = value) /; $cloudNotebooks

--- a/Source/Chatbook/InlineReferences.wl
+++ b/Source/Chatbook/InlineReferences.wl
@@ -146,7 +146,7 @@ parsePersona // beginDefinition;
 
 parsePersona[ name_String ] /; MemberQ[ $personaNames, name ] :=
     Append[
-        personaTemplateCell[ name, "Chosen", CreateUUID[ ] ],
+        personaTemplateCell[ name, "Chosen", createUUID[ ] ],
         TaggingRules -> <| "PersonaName" -> name, "PromptArguments" -> { } |>
     ];
 
@@ -163,7 +163,7 @@ parseModifier[ text_String ] := parseModifier @ functionInputSetting @ text;
 
 parseModifier[ { name_String, params___String } ] /; MemberQ[ $modifierNames, name ] :=
     Append[
-        modifierTemplateCell[ name, { params }, "Chosen", CreateUUID[ ] ],
+        modifierTemplateCell[ name, { params }, "Chosen", createUUID[ ] ],
         TaggingRules -> <| "PromptModifierName" -> name, "PromptArguments" -> { params } |>
     ];
 
@@ -180,7 +180,7 @@ parseFunction[ text_String ] := parseFunction @ functionInputSetting @ text;
 
 parseFunction[ { name_String, params___String } ] /; MemberQ[ $functionNames, name ] :=
     Append[
-        functionTemplateCell[ name, { params }, "Chosen", CreateUUID[ ] ],
+        functionTemplateCell[ name, { params }, "Chosen", createUUID[ ] ],
         TaggingRules -> <| "PromptFunctionName" -> name, "PromptArguments" -> { params } |>
     ];
 
@@ -277,7 +277,7 @@ insertModifierInputBox[ cell_CellObject ] :=
 insertModifierInputBox[ parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ modifierInputBox[ "", uuid ], "InlineModifierChooser", Background -> None ];
         NotebookWrite[ nbo, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -289,7 +289,7 @@ insertModifierInputBox[ args_List, cell_CellObject ] :=
 insertModifierInputBox[ args_List, parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ ParentCell @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ modifierInputBox[ args, uuid ], "InlineModifierChooser", Background -> None ];
         NotebookWrite[ parent, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -546,7 +546,7 @@ insertFunctionInputBox[ cell_CellObject ] :=
 insertFunctionInputBox[ parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ functionInputBox[ "", uuid ], "InlineFunctionChooser", Background -> None ];
         NotebookWrite[ nbo, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -558,7 +558,7 @@ insertFunctionInputBox[ args_List, cell_CellObject ] :=
 insertFunctionInputBox[ args_List, parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ ParentCell @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ functionInputBox[ args, uuid ], "InlineFunctionChooser", Background -> None ];
         NotebookWrite[ parent, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -825,7 +825,7 @@ insertTrailingFunctionInputBox[ cell_CellObject ] :=
 insertTrailingFunctionInputBox[ parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[
             BoxData @ ToBoxes @ trailingFunctionInputBox[ "", uuid ],
             "InlineTrailingFunctionChooser",
@@ -841,7 +841,7 @@ insertTrailingFunctionInputBox[ args_List, cell_CellObject ] :=
 insertTrailingFunctionInputBox[ args_List, parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ ParentCell @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[
             BoxData @ ToBoxes @ trailingFunctionInputBox[ args, uuid ],
             "InlineTrailingFunctionChooser",
@@ -1083,7 +1083,7 @@ insertPersonaInputBox[ cell_CellObject ] := insertPersonaInputBox[ cell, parentN
 insertPersonaInputBox[ parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ personaInputBox[ "", uuid ], "InlinePersonaChooser", Background -> None ];
         NotebookWrite[ nbo, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -1094,7 +1094,7 @@ insertPersonaInputBox[ name_String, cell_CellObject ] := insertPersonaInputBox[ 
 insertPersonaInputBox[ name_String, parent_CellObject, nbo_NotebookObject ] :=
     Module[ { uuid, cell },
         resolveInlineReferences @ ParentCell @ parent;
-        uuid = CreateUUID[ ];
+        uuid = createUUID[ ];
         cell = Cell[ BoxData @ ToBoxes @ personaInputBox[ name, uuid ], "InlinePersonaChooser", Background -> None ];
         NotebookWrite[ parent, cell ];
         FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -1473,7 +1473,7 @@ insertPersonaTemplate[ cell_CellObject ] := insertPersonaTemplate[ cell, parentN
 insertPersonaTemplate[ parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = personaTemplateCell[ "", "Input", uuid ];
 		NotebookWrite[ nbo, cellExpr ];
 		(* FIXME: Can we get rid of the need for this UUID, and use BoxReference-something? *)
@@ -1485,7 +1485,7 @@ insertPersonaTemplate[ name_String, cell_CellObject ] := insertPersonaTemplate[ 
 insertPersonaTemplate[ name_String, parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ ParentCell @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = personaTemplateCell[ name, "Input", uuid ];
 		NotebookWrite[ parent, cellExpr ];
 		FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -1679,7 +1679,7 @@ insertModifierTemplate[ cell_CellObject ] :=
 insertModifierTemplate[ parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = modifierTemplateCell[ "", {}, "Input", uuid ];
 		NotebookWrite[ nbo, cellExpr ];
 		(* FIXME: Can we get rid of the need for this UUID, and use BoxReference-something? *)
@@ -1691,7 +1691,7 @@ insertModifierTemplate[ name_String, cell_CellObject ] := insertModifierTemplate
 insertModifierTemplate[ name_String, parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ ParentCell @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = modifierTemplateCell[ name, {}, "Input", uuid ];
 		NotebookWrite[ parent, cellExpr ];
 		FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -1900,7 +1900,7 @@ insertFunctionTemplate[ cell_CellObject ] :=
 insertFunctionTemplate[ parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = functionTemplateCell[ "", {}, "Input", uuid ];
 		NotebookWrite[ nbo, cellExpr ];
 		(* FIXME: Can we get rid of the need for this UUID, and use BoxReference-something? *)
@@ -1912,7 +1912,7 @@ insertFunctionTemplate[ name_String, cell_CellObject ] := insertFunctionTemplate
 insertFunctionTemplate[ name_String, parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ ParentCell @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = functionTemplateCell[ name, {}, "Input", uuid ];
 		NotebookWrite[ parent, cellExpr ];
 		FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -2088,7 +2088,7 @@ insertWLTemplate[ cell_CellObject ] :=
 insertWLTemplate[ parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = wlTemplateCell[ "", "Input", uuid ];
 		NotebookWrite[ nbo, cellExpr ];
 		(* FIXME: Can we get rid of the need for this UUID, and use BoxReference-something? *)
@@ -2100,7 +2100,7 @@ insertWLTemplate[ name_String, cell_CellObject ] := insertWLTemplate[ name, cell
 insertWLTemplate[ name_String, parent_CellObject, nbo_NotebookObject ] :=
 	Module[ { uuid, cellExpr },
 		resolveInlineReferences @ ParentCell @ parent;
-		uuid = CreateUUID[ ];
+		uuid = createUUID[ ];
 		cellExpr = wlTemplateCell[ name, "Input", uuid ];
 		NotebookWrite[ parent, cellExpr ];
 		FrontEnd`MoveCursorToInputField[ nbo, uuid ]
@@ -2117,7 +2117,7 @@ $cloudInlineReferenceButtons = Block[ { NotebookTools`Mousedown = Mouseover[ #1,
                 Style[ tr[ "InlineReferencesInsertLabel" ], "Text" ],
                 Button[
                     First @ personaTemplateBoxes[ 1, "Persona", "Chosen", "PersonaInsertButton" ],
-                    With[ { name = InputString[ tr[ "InlineReferencesInsertPersonaPrompt" ] ], uuid = CreateUUID[ ] },
+                    With[ { name = InputString[ tr[ "InlineReferencesInsertPersonaPrompt" ] ], uuid = createUUID[ ] },
                         If[ MemberQ[ $personaNames, name ],
                             NotebookWrite[
                                 EvaluationNotebook[ ],
@@ -2143,7 +2143,7 @@ $cloudInlineReferenceButtons = Block[ { NotebookTools`Mousedown = Mouseover[ #1,
                 ],
                 Button[
                     First @ modifierTemplateBoxes[ 1, "Modifier", { }, "Chosen", "ModifierInsertButton" ],
-                    With[ { s = InputString[ tr[ "InlineReferencesInsertModifierPrompt" ] ], uuid = CreateUUID[ ] },
+                    With[ { s = InputString[ tr[ "InlineReferencesInsertModifierPrompt" ] ], uuid = createUUID[ ] },
                         Replace[
                             functionInputSetting @ s,
                             { name_String, args___String } :>
@@ -2172,7 +2172,7 @@ $cloudInlineReferenceButtons = Block[ { NotebookTools`Mousedown = Mouseover[ #1,
                 ],
                 Button[
                     First @ functionTemplateBoxes[ 1, "Function", { }, "Chosen", "FunctionInsertButton" ],
-                    With[ { s = InputString[ tr[ "InlineReferencesInsertFunctionPrompt" ] ], uuid = CreateUUID[ ] },
+                    With[ { s = InputString[ tr[ "InlineReferencesInsertFunctionPrompt" ] ], uuid = createUUID[ ] },
                         Replace[
                             functionInputSetting @ s,
                             { name_String, args___String } :>

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -438,7 +438,7 @@ pingSandboxKernel // beginDefinition;
 pingSandboxKernel[ kernel_LinkObject ] := Enclose[
     Module[ { uuid, return },
 
-        uuid   = CreateUUID[ ];
+        uuid   = createUUID[ ];
         return = $Failed;
 
         ConfirmMatch[

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -337,7 +337,7 @@ sendChat[ evalCell_CellObject, nbo_NotebookObject, appContainer_, settings0_ ] :
         container = <|
             "DynamicContent" -> ProgressIndicator[ Appearance -> "Percolate" ],
             "FullContent"    -> ProgressIndicator[ Appearance -> "Percolate" ],
-            "UUID"           -> CreateUUID[ ]
+            "UUID"           -> createUUID[ ]
         |>;
 
         $reformattedCell = None;
@@ -2997,7 +2997,7 @@ writeReformattedCell[ settings_, string0_String, cell_CellObject ] := Enclose[
             label    = RawBoxes @ TemplateBox[ { }, "MinimizedChat" ];
             pageData = CurrentValue[ cell, { TaggingRules, "PageData" } ];
             cellTags = CurrentValue[ cell, CellTags ];
-            uuid     = CreateUUID[ ];
+            uuid     = createUUID[ ];
             new      = reformatCell[ settings, string, tag, open, label, pageData, cellTags, uuid ];
 
             $lastChatString  = string;
@@ -3380,7 +3380,7 @@ restoreLastPage[ settings_, rules_Association, cellObject_CellObject ] := Enclos
         b64      = ConfirmBy[ pageData[ "Pages", pageData[ "CurrentPage" ] ], StringQ, "Base64" ];
         bytes    = ConfirmBy[ ByteArray @ b64, ByteArrayQ, "ByteArray" ];
         content  = ConfirmMatch[ BinaryDeserialize @ bytes, _TextData | _Association, "TextData" ];
-        uuid     = CreateUUID[ ];
+        uuid     = createUUID[ ];
 
         cell = Cell[
             If[ AssociationQ @ content, Lookup[ content, "Response" ], content ],

--- a/Source/Chatbook/Storage.wl
+++ b/Source/Chatbook/Storage.wl
@@ -334,7 +334,7 @@ ensureConversationUUID[ nbo_NotebookObject, settings0_Association ] := Enclose[
         settings = ConfirmBy[ <| AbsoluteCurrentChatSettings @ appContainer, settings0 |>, AssociationQ, "Settings" ];
         uuid = settings[ "ConversationUUID" ];
         If[ ! StringQ @ uuid,
-            uuid = ConfirmBy[ CreateUUID[ ], StringQ, "UUID" ];
+            uuid = ConfirmBy[ createUUID[ ], StringQ, "UUID" ];
             settings[ "ConversationUUID" ] = uuid;
             ConfirmBy[ CurrentChatSettings[ appContainer, "ConversationUUID" ] = uuid, StringQ, "SetUUID" ];
         ];
@@ -677,7 +677,7 @@ getChatMetadata // endDefinition;
 (*getChatUUID*)
 getChatUUID // beginDefinition;
 getChatUUID[ KeyValuePattern[ "ConversationUUID" -> id_String ] ] := id;
-getChatUUID[ _Association ] := CreateUUID[ ];
+getChatUUID[ _Association ] := createUUID[ ];
 getChatUUID // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Source/Chatbook/Utils.wl
+++ b/Source/Chatbook/Utils.wl
@@ -1109,7 +1109,7 @@ createUUID // endDefinition;
 (* ::Subsubsection::Closed:: *)
 (*createUUIDFallback*)
 createUUIDFallback // beginDefinition;
-createUUIDFallback[ ] := StringInsert[ IntegerString[ RandomInteger[ 2^128 ], 16, 32 ], "-", { 9, 13, 17, 21 } ];
+createUUIDFallback[ ] := StringInsert[ IntegerString[ RandomInteger[ 2^128 - 1 ], 16, 32 ], "-", { 9, 13, 17, 21 } ];
 createUUIDFallback // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Source/Chatbook/Utils.wl
+++ b/Source/Chatbook/Utils.wl
@@ -1095,6 +1095,25 @@ taskWaitYield // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*createUUID*)
+createUUID // beginDefinition;
+
+createUUID[ base_String: "" ] := Replace[
+    AbortProtect @ CreateUUID @ base,
+    Except[ _String ] :> base <> createUUIDFallback[ ]
+];
+
+createUUID // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*createUUIDFallback*)
+createUUIDFallback // beginDefinition;
+createUUIDFallback[ ] := StringInsert[ IntegerString[ RandomInteger[ 2^128 ], 16, 32 ], "-", { 9, 13, 17, 21 } ];
+createUUIDFallback // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*optionsAssociation*)
 optionsAssociation // beginDefinition;
 

--- a/Source/Chatbook/Utils.wl
+++ b/Source/Chatbook/Utils.wl
@@ -399,7 +399,7 @@ initializeProgressContainer[ container_Symbol ] := (
     container = <|
         "DynamicContent" -> $defaultProgress,
         "FullContent"    -> $defaultProgress,
-        "UUID"           -> CreateUUID[ ]
+        "UUID"           -> createUUID[ ]
     |>
 );
 
@@ -1209,7 +1209,7 @@ LogChatTiming[ eval_ ] := LogChatTiming[ eval, "None" ];
 
 LogChatTiming[ eval_, tag_String ] := (
     If[ ! NumberQ @ $chatStartTime, $chatStartTime = AbsoluteTime[ ] ];
-    If[ ! StringQ @ $chatEvaluationID, $chatEvaluationID = CreateUUID[ ] ];
+    If[ ! StringQ @ $chatEvaluationID, $chatEvaluationID = createUUID[ ] ];
     If[ ! MatchQ[ $timingLog, _Internal`Bag ], $timingLog = Internal`Bag[ ] ];
     logChatTiming[ eval, tag ]
 );
@@ -1245,7 +1245,7 @@ logChatTiming[ eval_, tag_String ] :=
         ];
 
         usedTime = fullTime - Total @ innerTimings[[All, "FullTiming"]];
-        
+
         Internal`StuffBag[ $timingLog, <|
                 "ChatEvaluationCell" -> $ChatEvaluationCell,
                 "Tag"                -> tag,


### PR DESCRIPTION
## Summary

Auto-generated bug reports (e.g. #1556) show crashes that originate from `CreateUUID[]` failing at the system level. `CreateUUID[]` ultimately delegates to a compiled `LibraryFunction` (``UUID`Private`generateUUID``, reached via ``UUID`UUID[]``). When that library call fails to return a string, `CreateUUID`'s wrapping ``StringJoin[UUID`UUID[]]`` errors out, and the failure propagates up through chat actions (`setServiceCallerAndID`, etc.).

This PR mitigates those failures by routing UUID generation through a new `createUUID` wrapper with a fallback:

- **`createUUID`** (`Source/Chatbook/Utils.wl`) — wraps `CreateUUID` in `AbortProtect`; if the result is not a string, it falls back to `createUUIDFallback`.
- **`createUUIDFallback`** — manually constructs a UUID-formatted string from a random 128-bit integer (`IntegerString[RandomInteger[2^128], 16, 32]` with hyphens inserted at positions 9/13/17/21), so a valid UUID is always returned.
- Replaced `CreateUUID` call sites across the paclet with `createUUID`.

### Other changes
- Added timing logging for `ChatbookAction`, tagged by action name.
- Fixed a `BuildPaclet.wls` failure when the snippet directory already exists in `Assets/`.
- Removed redundant console output.
- Ignore a stack dump file that can be generated by Claude Code.

## Issue

Fixes #1556.

> [!NOTE]
> This addresses the **symptom**: Chatbook will no longer crash when `CreateUUID[]` fails, since it now falls back to a locally-generated UUID (pure WL, no library dependency). The **underlying cause** — the compiled ``UUID`Private`generateUUID`` `LibraryFunction` behind `CreateUUID[]` failing at the kernel/system level — is outside the scope of this paclet and may still persist.

## Test plan
- [ ] `createUUID[]` returns a valid UUID-formatted string.
- [ ] `createUUIDFallback[]` returns a valid UUID-formatted string (32 hex chars with hyphens at positions 9, 13, 17, 21).
- [ ] `createUUID["prefix-"]` prepends the base string in both the normal and fallback paths.
- [ ] Existing test suite passes (`wolframscript -f Scripts/TestPaclet.wls`).
