### PR TITLE
Avoid directory-check race when deleting cloud vector database directory

### DIFF
--- a/Source/Chatbook/PromptGenerators/VectorDatabases.wl
+++ b/Source/Chatbook/PromptGenerators/VectorDatabases.wl
@@ -495,7 +495,10 @@ getVectorDBDirectory[ ] := Enclose[
 
         If[ $CloudEvaluation && dir === $cloudVectorDBDirectory,
             (* Automatically delete downloaded vector databases when NotebookAssistantCloudResources is available: *)
-            Quiet @ DeleteDirectory[ ChatbookFilesDirectory[ "VectorDatabases" ], DeleteContents -> True ]
+            Quiet @ DeleteDirectory[
+                ChatbookFilesDirectory[ "VectorDatabases", "EnsureDirectory" -> False ],
+                DeleteContents -> True
+            ]
         ];
 
         $vectorDBDirectory = dir


### PR DESCRIPTION
## Summary

Fixes a race condition when cleaning up downloaded vector databases in the cloud.

In `getVectorDBDirectory[]`, once cloud resources are available, the downloaded copy of the vector databases is deleted via `DeleteDirectory`. The path was being computed with `ChatbookFilesDirectory[ "VectorDatabases" ]`, which defaults to `"EnsureDirectory" -> True`. That code path runs ``GeneralUtilities`EnsureDirectory`` followed by `ConfirmBy[ …, DirectoryQ ]` — i.e. it creates and verifies the directory just so it can immediately be deleted.

When this runs in **multiple cloud processes simultaneously**, that ensure/confirm step can fail (the directory is being created/removed concurrently by another process), which surfaces as an internal failure.

## Fix

Pass `"EnsureDirectory" -> False` so the path is computed with a plain `FileNameJoin` and no filesystem check:

```wl
Quiet @ DeleteDirectory[
    ChatbookFilesDirectory[ "VectorDatabases", "EnsureDirectory" -> False ],
    DeleteContents -> True
]
```

This is safe because:
- We only need the path string in order to delete it — ensuring it exists first is pointless (and counterproductive) when the goal is removal.
- `DeleteDirectory` is already wrapped in `Quiet`, so a non-existent directory fails harmlessly.

This matches the existing `"EnsureDirectory" -> False` convention already used for delete paths in `Search.wl`.

## Test plan

- [x] `CodeInspector` on `Source/Chatbook/PromptGenerators/VectorDatabases.wl` — no new issues
- [x] Existing test suite passes (no behavioral change outside the cloud cleanup path)
- [ ] Manual verification in cloud: confirm downloaded vector databases are still cleaned up once `NotebookAssistantCloudResources` is available, with no failures when multiple kernels run concurrently

> Note: This path is gated on `$CloudEvaluation` and the race only manifests with multiple simultaneous cloud processes, so it cannot be reproduced in a standard desktop test environment.

## Related issue

No linked GitHub issue (auto-detected in cloud logs).
