### PR TITLE
Avoid directory-check race when computing the local vector database path

### DIFF
--- a/Source/Chatbook/PromptGenerators/VectorDatabases.wl
+++ b/Source/Chatbook/PromptGenerators/VectorDatabases.wl
@@ -173,7 +173,7 @@ makeDownloadURL // endDefinition;
 (* ::Subsection::Closed:: *)
 (*Paths*)
 $pacletVectorDBDirectory := FileNameJoin @ { $thisPaclet[ "Location" ], "Assets/VectorDatabases" };
-$localVectorDBDirectory  := ChatbookFilesDirectory @ { "VectorDatabases", $versionString };
+$localVectorDBDirectory  := ChatbookFilesDirectory[ { "VectorDatabases", $versionString }, "EnsureDirectory" -> False ];
 $cloudVectorDBDirectory  := PacletObject[ "Wolfram/NotebookAssistantCloudResources" ][ "AssetLocation", "VectorDatabases" ];
 
 $versionString := StringReplace[ ToString @ $VersionNumber, { "."~~EndOfString :> "-0", "." -> "-" } ];


### PR DESCRIPTION
## Summary

Follow-up to #1562 — fixes another instance of the same directory-check race condition, this time in the definition of `$localVectorDBDirectory` itself.

`$localVectorDBDirectory` was defined with a plain `ChatbookFilesDirectory[ … ]` call, which defaults to `"EnsureDirectory" -> True`. Because it's a `SetDelayed` (`:=`) path, **every reference** eagerly runs ``GeneralUtilities`EnsureDirectory`` followed by `ConfirmBy[ …, DirectoryQ ]` as a side effect — the exact ensure/confirm step that races under concurrent cloud processes.

That path is referenced in two places where the side effect is unwanted:

- **`getVectorDBDirectory[]`** builds its `sources` list from `$localVectorDBDirectory` purely to run a `vectorDBDirectoryQ` containment check. Merely listing the source creates and verifies the directory. This is the same function that performs the cloud cleanup `DeleteDirectory` fixed in #1562, so it hits the identical internal failure under multiple simultaneous cloud processes.
- **`downloadVectorDatabases[]`** passes `$localVectorDBDirectory` into `downloadVectorDatabases[ dir0_, … ]`, which already calls `ConfirmBy[ GeneralUtilities`EnsureDirectory @ dir0, DirectoryQ ]` itself when a download actually happens.

## Fix

```wl
$localVectorDBDirectory := ChatbookFilesDirectory[ { "VectorDatabases", $versionString }, "EnsureDirectory" -> False ];
```

Computing the path no longer touches the filesystem. This is safe because:

- The `getVectorDBDirectory[]` containment check only needs the path string — `vectorDBDirectoryQ` already tests `DirectoryQ` and returns `False` when the directory is absent, so there's nothing to gain by creating it first.
- `downloadVectorDatabases` explicitly ensures the directory (`GeneralUtilities`EnsureDirectory`) before writing to it, so the directory is still created when a download genuinely needs it.

This matches the `"EnsureDirectory" -> False` convention already used for the delete path in this same file (added in #1562) and in `Search.wl`.

## Test plan

- [x] `CodeInspector` on `Source/Chatbook/PromptGenerators/VectorDatabases.wl` — no new issues (only a pre-existing, unrelated `UnreachableConditionalDefinition` warning at line 549)
- [ ] Manual verification in cloud: confirm vector databases are still discovered/downloaded and the cloud cleanup still runs, with no internal failures when multiple kernels run concurrently

> Note: like #1562, this race only manifests under `$CloudEvaluation` with multiple simultaneous cloud processes, so it cannot be reproduced in a standard desktop test environment. The change is to path computation only and introduces no behavioral change on the desktop path.

## Related

- Same root cause as #1562 (*Avoid directory-check race when deleting cloud vector database directory*)
- No linked GitHub issue (auto-detected in cloud logs)
