### PR TITLE
Restore backslash escapes before parsing TeX math content

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -127,8 +127,9 @@ esc[ c_ ] := "\[EntityStart]" <> IntegerString @ FromDigits[ ToCharacterCode[ c,
 $mdEscapedCharacters = { "`", "$", "*", "_", "#", "|" };
 $$mdEscapedCharacter = Alternatives @@ Map[ "\\"<># &, $mdEscapedCharacters ];
 
-$mdEscapeRules   = "\\" <> # -> esc @ # & /@ $mdEscapedCharacters;
-$mdUnescapeRules = esc @ # -> # & /@ $mdEscapedCharacters;
+$mdEscapeRules    = "\\" <> # -> esc @ # & /@ $mdEscapedCharacters;
+$mdUnescapeRules  = esc @ # -> # & /@ $mdEscapedCharacters;
+$texUnescapeRules = esc @ # -> "\\" <> # & /@ $mdEscapedCharacters;
 
 (* ::**************************************************************************************************************:: *)
  (* ::Section::Closed:: *)
@@ -379,7 +380,7 @@ makeResultCell0[ mathCell[ name_String ] ] /; systemNameQ @ name && StringLength
     makeResultCell0 @ inlineCodeCell @ name;
 
 makeResultCell0[ mathCell[ math_String ] ] :=
-    With[ { boxes = makeTeXBoxes @ math },
+    With[ { boxes = makeTeXBoxes @ StringReplace[ math, $texUnescapeRules ] },
         If[ MatchQ[ boxes, _RawBoxes ],
             Cell @ BoxData @ toTeXBoxes @ boxes,
             makeResultCell0 @ inlineCodeCell @ math

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -23,7 +23,7 @@ VerificationTest[
    intact for it to render a literal dollar sign: *)
 VerificationTest[
     FirstCase[
-        Wolfram`Chatbook`FormatChatOutput[ "Here is some TeX: $$\\$123.45 / \\$6.78$$" ],
+        FormatChatOutput[ "Here is some TeX: $$\\$123.45 / \\$6.78$$" ],
         TemplateBox[ as_Association, "TeXAssistantTemplate" ] :> as,
         $Failed,
         Infinity
@@ -40,7 +40,7 @@ VerificationTest[
 (* The same holds for the other characters markdown escapes: *)
 VerificationTest[
     FirstCase[
-        Wolfram`Chatbook`FormatChatOutput[ "$$a \\_ b \\# c$$" ],
+        FormatChatOutput[ "$$a \\_ b \\# c$$" ],
         TemplateBox[ as_Association, "TeXAssistantTemplate" ] :> as,
         $Failed,
         Infinity
@@ -63,7 +63,7 @@ VerificationTest[
 
 (* Outside of math the backslash only marks the escape, so it is dropped instead of being kept: *)
 VerificationTest[
-    Wolfram`Chatbook`FormatChatOutput[ "Cost: \\$5 and \\$6" ],
+    FormatChatOutput[ "Cost: \\$5 and \\$6" ],
     RawBoxes @ Cell @ TextData @ { "Cost: $5 and $6" },
     SameTest -> MatchQ,
     TestID   -> "Markdown-Escaped-Dollar@@Tests/Formatting.wlt:65,1-70,2"

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -1,0 +1,70 @@
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`ChatbookTests`", FileNameJoin @ { DirectoryName[ $TestFileName ], "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/Formatting.wlt:4,1-9,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`Chatbook`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/Formatting.wlt:11,1-16,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*TeX Escapes*)
+
+(* Inside math the escape belongs to TeX rather than markdown, so the backslash has to reach the TeX parser
+   intact for it to render a literal dollar sign: *)
+VerificationTest[
+    FirstCase[
+        Wolfram`Chatbook`FormatChatOutput[ "Here is some TeX: $$\\$123.45 / \\$6.78$$" ],
+        TemplateBox[ as_Association, "TeXAssistantTemplate" ] :> as,
+        $Failed,
+        Infinity
+    ],
+    KeyValuePattern @ {
+        "input" -> "\\$123.45 / \\$6.78",
+        "boxes" -> FormBox[ RowBox @ { "$123.45", "/", "$6.78" }, TraditionalForm ],
+        "state" -> "Boxes"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "TeX-Escaped-Dollar@@Tests/Formatting.wlt:24,1-38,2"
+]
+
+(* The same holds for the other characters markdown escapes: *)
+VerificationTest[
+    FirstCase[
+        Wolfram`Chatbook`FormatChatOutput[ "$$a \\_ b \\# c$$" ],
+        TemplateBox[ as_Association, "TeXAssistantTemplate" ] :> as,
+        $Failed,
+        Infinity
+    ],
+    KeyValuePattern @ {
+        "input" -> "a \\_ b \\# c",
+        "boxes" -> FormBox[
+            RowBox @ { StyleBox[ "a", "TI" ], "_", StyleBox[ "b", "TI" ], "#", StyleBox[ "c", "TI" ] },
+            TraditionalForm
+        ],
+        "state" -> "Boxes"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "TeX-Escaped-Underscore-And-Hash@@Tests/Formatting.wlt:41,1-58,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Markdown Escapes*)
+
+(* Outside of math the backslash only marks the escape, so it is dropped instead of being kept: *)
+VerificationTest[
+    Wolfram`Chatbook`FormatChatOutput[ "Cost: \\$5 and \\$6" ],
+    RawBoxes @ Cell @ TextData @ { "Cost: $5 and $6" },
+    SameTest -> MatchQ,
+    TestID   -> "Markdown-Escaped-Dollar@@Tests/Formatting.wlt:65,1-70,2"
+]


### PR DESCRIPTION
## Summary

A markdown-escaped character inside a math block was mangled instead of rendered. `$$\$123.45 / \$6.78$$` produced garbage where the dollar signs should be.

Before, on `main`:

```wl
In[1]:= Needs[ "Wolfram`Chatbook`" ]
In[2]:= FormatChatOutput[ "Here is some TeX: $$\$123.45 / \$6.78$$" ] // InputForm
```

```wl
<|"boxes" -> FormBox[RowBox[{"ï¸36ï¹123.45", "/", "ï¸36ï¹6.78"}], TraditionalForm],
  "errors" -> {}, "input" -> "$123.45 / $6.78", "state" -> "Boxes"|>
```

After:

```wl
<|"boxes" -> FormBox[RowBox[{"$123.45", "/", "$6.78"}], TraditionalForm],
  "errors" -> {}, "input" -> "\\$123.45 / \\$6.78", "state" -> "Boxes"|>
```

## Root cause

`reformatTextData0` rewrites markdown escapes like `\$` into a private sentinel (`esc`, a `\[EntityStart]…\[EntityEnd]` pair) before the text is parsed into cells, then restores them afterward with `$mdUnescapeRules`. Those rules drop the backslash, which is right for body text — there the backslash only marks the escape, so `\$` should render as a bare `$`.

Math content never takes that path. It is handed to `makeTeXBoxes` as a raw string, so the sentinel reached the TeX parser verbatim and came back as the mojibake above, once those private use characters were reinterpreted.

The two halves of the `"before"` output fail differently, which is worth noting since only one of them is visible to users:

- `"boxes"` was mangled by the TeX parser, and no longer contained a sentinel for anything downstream to recognize.
- `"input"` still held real sentinels, so the outer unescape sweep in `reformatTextData0` restored them — to a bare `$`, silently stripping the TeX escape rather than showing mojibake.

## Fix

Unescape math with the new `$texUnescapeRules`, which restores the sentinel to `\<char>` and keeps the backslash. Inside `$$...$$` the escape belongs to TeX rather than markdown, so the backslash has to reach the parser: `\$` is how TeX renders a literal dollar sign, and likewise `\_` and `\#`. The remaining escaped characters (`` ` ``, `*`, `|`) keep whatever meaning TeX assigns the sequence, which still beats passing the sentinel through.

The change sits on the general `mathCell` definition only. The digits-only and system-name definitions above it can't hold a sentinel, and the fallback to `inlineCodeCell` returns strings, which `$mdUnescapeRules` still catches on the way out.

## Test plan

- [x] New `Tests/Formatting.wlt` — 5/5 pass. `Formatting.wl` had no test coverage before this.
- [x] Confirmed the tests actually catch the bug: both TeX tests were run against the pre-fix code and **fail** there, reproducing the exact mojibake above. Without that check a passing test proves nothing here.
- [x] `TeX-Escaped-Dollar` pins the reported case; `TeX-Escaped-Underscore-And-Hash` covers `\_` and `\#` to show the rule generalizes.
- [x] `Markdown-Escaped-Dollar` is a guard, not a regression test: it passes both before and after, and pins the neighboring markdown path (`\$` → `$` in body text) that this change could otherwise have quietly broken. The two unescape rule sets are easy to confuse.
- [x] `CodeInspector` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
