### PR TITLE
Accept extra backslashes in Freeform autocorrect rules

### DIFF
--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1405,10 +1405,11 @@ $llmAutoCorrectRules := $llmAutoCorrectRules = Flatten @ {
        character, which should reduce the likelihood of incorrect unicode characters being used instead. *)
     RegularExpression["\\\\u[Ff]351"] -> "\[FreeformPrompt]",
     RegularExpression["\\\\u[Ff][Ff]1[Dd]"] -> "\[FreeformPrompt]",
-    "\:ff1d" -> "\[FreeformPrompt]",
-    "\\"<>"[FreeformInput]" -> "\[FreeformPrompt]",
-    "\\"<>"[FreeformEntity]" -> "\[FreeformPrompt]",
-    "\\"<>"[FreeformPrompt]" -> "\[FreeformPrompt]",
+    "\\"... ~~ "\:ff1d" -> "\[FreeformPrompt]",
+    "\\".. ~~ "[FreeformInput]" -> "\[FreeformPrompt]",
+    "\\".. ~~ "[FreeformEntity]" -> "\[FreeformPrompt]",
+    "\\".. ~~ "[FreeformPrompt]" -> "\[FreeformPrompt]",
+    "\\".. ~~ "[RawEscape][FreeformPrompt]" -> "\[FreeformPrompt]",
     (* ============================================== *)
     "\n<|image_sentinel|>\n" :> "\n",
     "<|image_sentinel|>" :> "",

--- a/Tests/AutoCorrect.wlt
+++ b/Tests/AutoCorrect.wlt
@@ -73,4 +73,39 @@ VerificationTest[
     TestID   -> "AutoCorrect-Preserve-Structure@@Tests/AutoCorrect.wlt:69,1-74,2"
 ]
 
+(* Models sometimes over-escape the leading backslash, so any number of them must be accepted *)
+VerificationTest[
+    Wolfram`Chatbook`Common`autoCorrect[ "\\\\[FreeformPrompt][\"France\", Entity]" ],
+    "\[FreeformPrompt][\"France\", Entity]",
+    SameTest -> MatchQ,
+    TestID   -> "AutoCorrect-Extra-Backslashes@@Tests/AutoCorrect.wlt:77,1-82,2"
+]
+
+VerificationTest[
+    (* Concatenated to keep the unrecognized long names out of the source text *)
+    Wolfram`Chatbook`Common`autoCorrect /@ {
+        "\\" <> "[FreeformInput][\"a\"]",
+        "\\\\" <> "[FreeformInput][\"a\"]",
+        "\\" <> "[FreeformEntity][\"a\"]",
+        "\\\\" <> "[FreeformEntity][\"a\"]"
+    },
+    ConstantArray[ "\[FreeformPrompt][\"a\"]", 4 ],
+    SameTest -> MatchQ,
+    TestID   -> "AutoCorrect-Freeform-Aliases@@Tests/AutoCorrect.wlt:84,1-95,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`Common`autoCorrect[ "\\[RawEscape][FreeformPrompt][\"France\"]" ],
+    "\[FreeformPrompt][\"France\"]",
+    SameTest -> MatchQ,
+    TestID   -> "AutoCorrect-RawEscape@@Tests/AutoCorrect.wlt:97,1-102,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`Common`autoCorrect[ "\\\:ff1d[\"a\", Entity]" ],
+    "\[FreeformPrompt][\"a\", Entity]",
+    SameTest -> MatchQ,
+    TestID   -> "AutoCorrect-Backslash-Fullwidth@@Tests/AutoCorrect.wlt:104,1-109,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Models that are sent `\[FreeformPrompt]` as pure ASCII sometimes over-escape it on the way back, and the extra backslash survived into the formatted output.

Before, on `main`:

```wl
In[1]:= Needs[ "Wolfram`Chatbook`" ]
In[2]:= Wolfram`Chatbook`Common`autoCorrect[ "\\[FreeformPrompt][\"France\", Entity]" ] // InputForm
Out[2]= "\\[FreeformPrompt][\"France\", Entity]"
```

After:

```wl
Out[2]= "\[FreeformPrompt][\"France\", Entity]"
```

The `\[RawEscape][FreeformPrompt]` spelling was not recognized at all, and passed through untouched:

```wl
(* before *) "\[RawEscape][FreeformPrompt][\"France\", Entity]"
(* after  *) "\[FreeformPrompt][\"France\", Entity]"
```

## Root cause

`replaceUnicodeCharacters` sends the `\[FreeformPrompt]` character to models that mishandle the private use area as its ASCII escape, and `autoCorrect` restores the character on the way back via `$llmAutoCorrectRules`.

The restore rules were plain string literals, so each matched exactly one leading backslash:

```wl
"\:ff1d" -> "\[FreeformPrompt]",
"\\"<>"[FreeformInput]" -> "\[FreeformPrompt]",
```

When a model wrote `\[FreeformPrompt]`, the rule matched the *last* backslash plus the token and consumed only those, leaving the earlier backslash in place — one stray backslash in front of the entity rather than a clean `\[FreeformPrompt]`.

## Fix

Match one or more leading backslashes (`"\\"..`) for the three long name spellings, allow any number (`"\\"...`) before the fullwidth equals sign, and add a rule for the `\[RawEscape][FreeformPrompt]` spelling.

Rule order still holds. The `\[RawEscape]` rule sits *after* the plain `\[FreeformPrompt]` rule, but the earlier rules require their token immediately after the backslashes, so they cannot match `\[RawEscape][FreeformPrompt]` first — verified rather than assumed.

Scope note: this handles the *literal text* `\[RawEscape][FreeformPrompt]`. If a model emits an actual ESC character (U+001B) followed by `[FreeformPrompt]`, it is still not caught — `$longNameCharacters` rewrites the ESC to `\[RawEscape]` later in the same rule list. Left alone since it has not been observed.

## Test plan

- [x] `Tests/AutoCorrect.wlt` — 12/12 pass (8 existing + 4 new).
- [x] Confirmed the tests actually catch the bug: all four new tests were run against the pre-fix rules and **fail** there. Without that check a passing test proves nothing here.
- [x] `AutoCorrect-Extra-Backslashes` pins the reported case; `AutoCorrect-Freeform-Aliases` covers the `\[FreeformInput]` / `\[FreeformEntity]` spellings at one and two backslashes; `AutoCorrect-RawEscape` and `AutoCorrect-Backslash-Fullwidth` cover the remaining two new rules.
- [x] The 4 pre-existing `autoCorrect` tests still pass, including the `replaceUnicodeCharacters` round-trip, so the broadened matching does not over-reach.
- [x] `Tests/WolframLanguageToolEvaluate.wlt` — 49/49 pass. It is the only other test file exercising `autoCorrect`.
- [x] `CodeInspector` clean on both changed files. The alias test inputs are built by concatenation rather than written literally, since `\[FreeformInput]` and `\[FreeformEntity]` are not recognized long names and are otherwise reported as errors — the same reason `$llmAutoCorrectRules` spells them that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
