### PR TITLE
Emulate stop tokens client-side for models that do not support them

### DIFF
--- a/Scripts/TestPaclet.wls
+++ b/Scripts/TestPaclet.wls
@@ -75,6 +75,12 @@ If[ ! FileExistsQ @ $mxFile && getBooleanArgument[ { "b", "build" }, True ],
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Run Tests*)
+(* Suppress LLM-related messages during tests. *)
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+Quiet[ LLMSynthesize, LLMServices`Defaults`Private`LLMFunctions::llmrstrt ];
+(* :!CodeAnalysis::EndBlock:: *)
+
 (* This is a hack to avoid a mysterious issue with the FE not finding the chatbook stylesheet
    the first time a test is run: *)
 If[ FileExistsQ @ $ccsTests, UsingFrontEnd @ TestReport @ $ccsTests ];

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -31,6 +31,11 @@ $maxTagLength = Max[ StringLength /@ (List @@ $$severityTag) ] + 2;
 (*Initialization*)
 $buffer = "";
 
+(* State for emulated stop tokens (used when the model does not support server-side stop tokens): *)
+$emulatedStopBuffer        = "";
+$emulatedStopTriggered     = False;
+$lastEmulatedStopDiscarded = None;
+
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*AgentEvaluate*)
@@ -905,7 +910,9 @@ chatSubmit // Attributes = { HoldFirst };
 
 chatSubmit[ args__ ] := Quiet[
     If[ ! MatchQ[ $debugLog, _Internal`Bag ], $debugLog = Internal`Bag[ ] ];
-    $receivedToolCall = False;
+    $receivedToolCall      = False;
+    $emulatedStopBuffer    = "";
+    $emulatedStopTriggered = False;
     rasterizeBlock @ chatSubmit0 @ args,
     {
         ServiceConnections`SavedConnections::wname,
@@ -961,6 +968,11 @@ chatSubmit0[
         |>;
 
         content = extractBodyChunks @ chunks;
+
+        (* There's no streaming here, so the whole response is checked for an emulated stop token at once: *)
+        If[ emulateStopTokensQ @ settings && MatchQ[ content, { __String } ],
+            content = { emulatedStopTokenTrim[ container, StringJoin @ content ] }
+        ];
 
         writeChunk[ <| "ExtractedBodyChunks" -> content |>, Dynamic @ container, cellObject ];
 
@@ -1148,7 +1160,8 @@ chatHandlers[ container_, cellObject_, settings_ ] :=
             handlers      = getHandlerFunctions @ settings,
             useTasks      = feTaskQ @ settings,
             toolFormatter = getToolFormatter @ settings,
-            stop          = makeStopTokens @ settings
+            stop          = makeStopTokens @ settings,
+            stopEmulation = emulateStopTokensQ @ settings
         },
         {
             bodyChunkHandler    = Lookup[ handlers, "BodyChunkReceived", None ],
@@ -1170,11 +1183,28 @@ chatHandlers[ container_, cellObject_, settings_ ] :=
                         $timeToFirstToken = AbsoluteTime[ ] - $chatStartTime;
                         addHandlerArguments[ "TimeToFirstToken" -> Quantity[ $timeToFirstToken, "Seconds" ] ];
                     ];
-                    With[ { as = <| #, "ExtractedBodyChunks" -> extractBodyChunks @ # |> },
-                        bodyChunkHandler[ as ];
-                        Internal`StuffBag[ $debugLog, $lastStatus = as ];
-                        checkFinishReason[ as ];
-                        writeChunk[ as, Dynamic @ container, cellObject ]
+                    (* If an emulated stop token was previously detected, discard any remaining buffered text: *)
+                    If[ ! (stopEmulation && $emulatedStopTriggered),
+                        With[
+                            {
+                                as = applyEmulatedStopTokens[
+                                    container,
+                                    stopEmulation,
+                                    <| #, "ExtractedBodyChunks" -> extractBodyChunks @ # |>
+                                ]
+                            },
+                            bodyChunkHandler[ as ];
+                            Internal`StuffBag[ $debugLog, $lastStatus = as ];
+                            checkFinishReason[ as ];
+                            writeChunk[ as, Dynamic @ container, cellObject ];
+                            If[ stopEmulation && $emulatedStopTriggered,
+                                (* An emulated stop token was just detected, so end the streaming task now and
+                                   process the response the same way the "TaskFinished" handler would have: *)
+                                Quiet[ TaskRemove @ $lastTask, TaskRemove::timnf ];
+                                logUsage @ container;
+                                checkResponse[ $settings, Unevaluated @ container, cellObject, as ]
+                            ]
+                        ]
                     ]
                 ]
             ],
@@ -1188,12 +1218,17 @@ chatHandlers[ container_, cellObject_, settings_ ] :=
                         $dynamicSplit        = dynamicSplit,
                         $settings            = settings
                     },
-                    taskFinishedHandler[ #1 ];
-                    Internal`StuffBag[ $debugLog, $lastStatus = #1 ];
-                    checkFinishReason[ #1 ];
-                    logUsage @ container;
-                    trimStopTokens[ container, stop ];
-                    checkResponse[ $settings, Unevaluated @ container, cellObject, #1 ]
+                    If[ stopEmulation && $emulatedStopTriggered,
+                        (* The response was already processed when the emulated stop token was detected: *)
+                        Internal`StuffBag[ $debugLog, $lastStatus = #1 ]
+                        ,
+                        taskFinishedHandler[ #1 ];
+                        Internal`StuffBag[ $debugLog, $lastStatus = #1 ];
+                        checkFinishReason[ #1 ];
+                        logUsage @ container;
+                        trimStopTokens[ container, stop ];
+                        checkResponse[ $settings, Unevaluated @ container, cellObject, #1 ]
+                    ]
                 ]
             ]
         |>
@@ -1219,6 +1254,132 @@ trimStopTokens[ container_, { ___String } | _Missing ] :=
     Null;
 
 trimStopTokens // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*emulateStopTokensQ*)
+
+(* Models that do not support stop tokens (e.g. gpt-5 and later) cannot be stopped server-side when they write the
+   tool call end token, so the end token needs to be detected client-side as content arrives instead. Without this,
+   a model that keeps writing after "/exec" would bury its tool call in extra text (typically hallucinating the tool
+   result), and even a model that correctly ends its response after writing "/exec" would leave a trailing "/exec"
+   that prevents `simpleToolRequestParser` from identifying the tool call. *)
+
+emulateStopTokensQ // beginDefinition;
+
+emulateStopTokensQ[ settings_Association ] := TrueQ @ And[
+    settings[ "ToolMethod" ] === "Simple",
+    TrueQ @ settings[ "ToolsEnabled" ],
+    ! MatchQ[ makeStopTokens @ settings, { __String } ]
+];
+
+emulateStopTokensQ // endDefinition;
+
+
+$emulatedStopTokens = { "\n/exec" };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*applyEmulatedStopTokens*)
+applyEmulatedStopTokens // beginDefinition;
+applyEmulatedStopTokens // Attributes = { HoldFirst };
+
+applyEmulatedStopTokens[ container_, False, as_Association ] :=
+    as;
+
+applyEmulatedStopTokens[ container_, True, as: KeyValuePattern[ "ExtractedBodyChunks" -> strings: { __String } ] ] :=
+    <| as, "ExtractedBodyChunks" -> { emulatedStopTokenTrim[ container, StringJoin @ strings ] } |>;
+
+applyEmulatedStopTokens[ container_, True, as_Association ] :=
+    as;
+
+applyEmulatedStopTokens // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*emulatedStopTokenTrim*)
+
+(* Accumulates the raw streamed text for the current chat round in `$emulatedStopBuffer` and checks it for stop
+   tokens. The buffer only contains text from the current round, so stop tokens belonging to completed tool calls
+   from earlier rounds (already part of the container content) can never match. If a stop token is found, sets
+   `$emulatedStopTriggered` and returns only the text that comes before it. Since a stop token can arrive split
+   across several chunks, its initial characters may have already been written to the container by previous calls,
+   in which case they are removed from the container content. *)
+
+emulatedStopTokenTrim // beginDefinition;
+emulatedStopTokenTrim // Attributes = { HoldFirst };
+
+emulatedStopTokenTrim[ container_, text_String ] := Enclose[
+    Module[ { previous, buffer, positions, start },
+
+        previous  = ConfirmBy[ $emulatedStopBuffer, StringQ, "Buffer" ];
+        buffer    = $emulatedStopBuffer = previous <> text;
+        positions = StringPosition[ buffer, $emulatedStopTokens ];
+
+        If[ positions === { },
+            (* No stop token appears in the response so far, so continue streaming normally: *)
+            text
+            ,
+            (* Otherwise everything from the start of the first stop token onward gets discarded: *)
+            $emulatedStopTriggered = True;
+            start = ConfirmBy[ Min @ positions[[ All, 1 ]], IntegerQ, "Position" ];
+            $lastEmulatedStopDiscarded = StringDrop[ buffer, start - 1 ];
+            If[ start > StringLength @ previous
+                ,
+                (* The stop token begins within the newly received text: *)
+                StringTake[ text, start - StringLength[ previous ] - 1 ]
+                ,
+                (* The stop token started in a previous chunk, so characters that have already been written to the
+                   container need to be removed: *)
+                trimPartialStopToken[ container, StringTake[ buffer, { start, StringLength @ previous } ] ];
+                ""
+            ]
+        ]
+    ],
+    throwInternalFailure
+];
+
+emulatedStopTokenTrim // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*trimPartialStopToken*)
+trimPartialStopToken // beginDefinition;
+trimPartialStopToken // Attributes = { HoldFirst };
+
+trimPartialStopToken[ container_, partial_String ] := (
+    If[ StringQ @ container[ "FullContent" ],
+        container[ "FullContent" ] = dropPartialSuffix[ container[ "FullContent" ], partial ]
+    ];
+    If[ StringQ @ container[ "DynamicContent" ],
+        container[ "DynamicContent" ] = dropPartialSuffix[ container[ "DynamicContent" ], partial ]
+    ]
+);
+
+trimPartialStopToken // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*dropPartialSuffix*)
+
+(* Removes the longest trailing portion of `partial` from the end of `string`. The dynamic content may have already
+   had earlier text moved into static output, so it might only end with some of the partial text. *)
+
+dropPartialSuffix // beginDefinition;
+
+dropPartialSuffix[ string_String, partial_String ] :=
+    dropPartialSuffix[ string, partial, StringLength @ partial ];
+
+dropPartialSuffix[ string_String, partial_String, 0 ] :=
+    string;
+
+dropPartialSuffix[ string_String, partial_String, n_Integer ] :=
+    If[ StringEndsQ[ string, StringTake[ partial, -n ] ],
+        StringDrop[ string, -n ],
+        dropPartialSuffix[ string, partial, n - 1 ]
+    ];
+
+dropPartialSuffix // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/SendChat.wl
+++ b/Source/Chatbook/SendChat.wl
@@ -1201,6 +1201,12 @@ chatHandlers[ container_, cellObject_, settings_ ] :=
                                 (* An emulated stop token was just detected, so end the streaming task now and
                                    process the response the same way the "TaskFinished" handler would have: *)
                                 Quiet[ TaskRemove @ $lastTask, TaskRemove::timnf ];
+                                taskFinishedHandler @ <|
+                                    as,
+                                    "TaskStatus"            -> "Finished",
+                                    "EventName"             -> "TaskFinished",
+                                    "EmulatedStopTriggered" -> True
+                                |>;
                                 logUsage @ container;
                                 checkResponse[ $settings, Unevaluated @ container, cellObject, as ]
                             ]

--- a/Tests/EmulatedStopTokens.wlt
+++ b/Tests/EmulatedStopTokens.wlt
@@ -1,0 +1,348 @@
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`ChatbookTests`", FileNameJoin @ { DirectoryName[ $TestFileName ], "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/EmulatedStopTokens.wlt:4,1-9,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`Chatbook`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/EmulatedStopTokens.wlt:11,1-16,2"
+]
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* Models that do not support server-side stop tokens (e.g. gpt-5 and later) rely on client-side detection of the
+   "\n/exec" end token when using the "Simple" tool method. These tests simulate the per-chunk trimming that occurs
+   in the chat submit handlers. *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*emulateStopTokensQ*)
+VerificationTest[
+    Wolfram`Chatbook`SendChat`Private`emulateStopTokensQ @ <|
+        "ToolMethod"   -> "Simple",
+        "ToolsEnabled" -> True,
+        "StopTokens"   -> Missing[ "NotSupported" ]
+    |>,
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "EmulateStopTokensQ-SimpleNoStopTokens@@Tests/EmulatedStopTokens.wlt:28,1-37,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`SendChat`Private`emulateStopTokensQ /@ {
+        (* Model supports stop tokens, so the server handles them: *)
+        <| "ToolMethod" -> "Simple", "ToolsEnabled" -> True, "StopTokens" -> { "\n/exec" } |>,
+        (* Only the "Simple" tool method is currently emulated: *)
+        <| "ToolMethod" -> "Textual", "ToolsEnabled" -> True, "StopTokens" -> Missing[ "NotSupported" ] |>,
+        (* No tools means nothing to detect: *)
+        <| "ToolMethod" -> "Simple", "ToolsEnabled" -> False, "StopTokens" -> Missing[ "NotSupported" ] |>
+    },
+    { False, False, False },
+    SameTest -> MatchQ,
+    TestID   -> "EmulateStopTokensQ-NotApplicable@@Tests/EmulatedStopTokens.wlt:39,1-51,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Streaming simulation*)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Model ends response after writing /exec*)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { container },
+            container = <| "DynamicContent" -> "", "FullContent" -> "" |>;
+            Scan[
+                Function[ chunk,
+                    If[ ! TrueQ @ Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                        With[
+                            {
+                                text = StringJoin @@ Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                                    container,
+                                    True,
+                                    <| "ExtractedBodyChunks" -> { chunk } |>
+                                ][ "ExtractedBodyChunks" ]
+                            },
+                            container[ "DynamicContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "DynamicContent" ],
+                                    text
+                                ];
+                            container[ "FullContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "FullContent" ],
+                                    text
+                                ]
+                        ]
+                    ]
+                ],
+                { "Some text\n\n/wl\nPrime[123]", "\n/exec" }
+            ];
+            {
+                container[ "FullContent" ],
+                container[ "DynamicContent" ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered
+            }
+        ]
+    ],
+    { "Some text\n\n/wl\nPrime[123]", "Some text\n\n/wl\nPrime[123]", True },
+    SameTest -> MatchQ,
+    TestID   -> "EmulatedStop-CleanStop@@Tests/EmulatedStopTokens.wlt:60,1-104,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Model continues writing after /exec*)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { container },
+            container = <| "DynamicContent" -> "", "FullContent" -> "" |>;
+            Scan[
+                Function[ chunk,
+                    If[ ! TrueQ @ Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                        With[
+                            {
+                                text = StringJoin @@ Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                                    container,
+                                    True,
+                                    <| "ExtractedBodyChunks" -> { chunk } |>
+                                ][ "ExtractedBodyChunks" ]
+                            },
+                            container[ "DynamicContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "DynamicContent" ],
+                                    text
+                                ];
+                            container[ "FullContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "FullContent" ],
+                                    text
+                                ]
+                        ]
+                    ]
+                ],
+                { "/wl\nPrime[123]\n", "/exec\nHallucinated **answer** here.", "\n\nMore text." }
+            ];
+            {
+                container[ "FullContent" ],
+                container[ "DynamicContent" ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered
+            }
+        ]
+    ],
+    { "/wl\nPrime[123]", "/wl\nPrime[123]", True },
+    SameTest -> MatchQ,
+    TestID   -> "EmulatedStop-DiscardsHallucinatedContinuation@@Tests/EmulatedStopTokens.wlt:109,1-153,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Stop token split across several chunks*)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { container },
+            container = <| "DynamicContent" -> "", "FullContent" -> "" |>;
+            Scan[
+                Function[ chunk,
+                    If[ ! TrueQ @ Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                        With[
+                            {
+                                text = StringJoin @@ Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                                    container,
+                                    True,
+                                    <| "ExtractedBodyChunks" -> { chunk } |>
+                                ][ "ExtractedBodyChunks" ]
+                            },
+                            container[ "DynamicContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "DynamicContent" ],
+                                    text
+                                ];
+                            container[ "FullContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "FullContent" ],
+                                    text
+                                ]
+                        ]
+                    ]
+                ],
+                { "/wl\nRandomReal[]", "\n/e", "xec", "\nmore junk" }
+            ];
+            {
+                container[ "FullContent" ],
+                container[ "DynamicContent" ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered
+            }
+        ]
+    ],
+    { "/wl\nRandomReal[]", "/wl\nRandomReal[]", True },
+    SameTest -> MatchQ,
+    TestID   -> "EmulatedStop-SplitStopToken@@Tests/EmulatedStopTokens.wlt:158,1-202,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Response without any tool calls streams normally*)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { container },
+            container = <| "DynamicContent" -> "", "FullContent" -> "" |>;
+            Scan[
+                Function[ chunk,
+                    If[ ! TrueQ @ Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                        With[
+                            {
+                                text = StringJoin @@ Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                                    container,
+                                    True,
+                                    <| "ExtractedBodyChunks" -> { chunk } |>
+                                ][ "ExtractedBodyChunks" ]
+                            },
+                            container[ "DynamicContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "DynamicContent" ],
+                                    text
+                                ];
+                            container[ "FullContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "FullContent" ],
+                                    text
+                                ]
+                        ]
+                    ]
+                ],
+                { "Just a normal ", "response with no tools." }
+            ];
+            {
+                container[ "FullContent" ],
+                container[ "DynamicContent" ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered
+            }
+        ]
+    ],
+    { "Just a normal response with no tools.", "Just a normal response with no tools.", False },
+    SameTest -> MatchQ,
+    TestID   -> "EmulatedStop-NoToolCall@@Tests/EmulatedStopTokens.wlt:207,1-251,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*Stop tokens from previous rounds are ignored*)
+
+(* The container already holds a completed tool call from an earlier round of the conversation. Only the new
+   round's "\n/exec" may trigger, and the resulting content must parse as a tool call for `NextPrime`. *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { prior, container, request },
+            prior = StringJoin[
+                "/wl\nPrime[123456789]\n/exec\nRESULT\nOut[1]= 2543568463\nENDRESULT(70ua8j1ev)\n\n",
+                "The prime is **2543568463**.\n\n"
+            ];
+            container = <| "DynamicContent" -> prior, "FullContent" -> prior |>;
+            Scan[
+                Function[ chunk,
+                    If[ ! TrueQ @ Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                        With[
+                            {
+                                text = StringJoin @@ Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                                    container,
+                                    True,
+                                    <| "ExtractedBodyChunks" -> { chunk } |>
+                                ][ "ExtractedBodyChunks" ]
+                            },
+                            container[ "DynamicContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "DynamicContent" ],
+                                    text
+                                ];
+                            container[ "FullContent" ] =
+                                Wolfram`Chatbook`SendChat`Private`appendStringContent[
+                                    container[ "FullContent" ],
+                                    text
+                                ]
+                        ]
+                    ]
+                ],
+                { "/wl\nNextPrime[2543568463]", "\n/exec\n\nThe next prime is **2543568499**." }
+            ];
+            request = Wolfram`Chatbook`Common`simpleToolRequestParser @ container[ "FullContent" ];
+            {
+                StringEndsQ[ container[ "FullContent" ], "/wl\nNextPrime[2543568463]" ],
+                StringContainsQ[ container[ "FullContent" ], "ENDRESULT(70ua8j1ev)" ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered,
+                Lookup[ Association @ request[[ 2 ]][ "ParameterValues" ], "code" ]
+            }
+        ]
+    ],
+    { True, True, True, "NextPrime[2543568463]" },
+    SameTest -> MatchQ,
+    TestID   -> "EmulatedStop-MultiRound@@Tests/EmulatedStopTokens.wlt:259,1-309,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*applyEmulatedStopTokens*)
+
+(* Pass-through cases: emulation disabled or no extracted content strings *)
+VerificationTest[
+    Block[
+        {
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopBuffer    = "",
+            Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered = False
+        },
+        Module[ { container },
+            container = <| "DynamicContent" -> "", "FullContent" -> "" |>;
+            {
+                Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                    container,
+                    False,
+                    <| "ExtractedBodyChunks" -> { "a\n/exec\nb" } |>
+                ],
+                Wolfram`Chatbook`SendChat`Private`applyEmulatedStopTokens[
+                    container,
+                    True,
+                    <| "ExtractedBodyChunks" -> { } |>
+                ],
+                Wolfram`Chatbook`SendChat`Private`$emulatedStopTriggered
+            }
+        ]
+    ],
+    {
+        <| "ExtractedBodyChunks" -> { "a\n/exec\nb" } |>,
+        <| "ExtractedBodyChunks" -> { } |>,
+        False
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ApplyEmulatedStopTokens-PassThrough@@Tests/EmulatedStopTokens.wlt:316,1-346,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Models like gpt-5 and later do not support server-side stop tokens, which breaks the simple tool calling method (``ToolMethod -> "Simple"``) in two ways:

- The model frequently continues its response after writing `/exec` instead of ending it, burying the tool call in extra text and hallucinating the tool result instead of ever executing the tool.
- Even when the model correctly ends its response after `/exec`, the trailing `/exec` prevents `simpleToolRequestParser` from identifying the tool call (its completed-call `StringDelete` pattern greedily consumes everything up to the last `/exec`), so textual tool calls from these models never executed at all.

This adds client-side emulation of the `"\n/exec"` stop token, active only when `ToolMethod -> "Simple"`, tools are enabled, and the model has no usable stop tokens:

- The raw streamed text of the current chat round is accumulated in a buffer and watched for `"\n/exec"`. Since the buffer only ever contains the current round's completion text, stop tokens belonging to completed tool calls from earlier rounds can never match, and `autoCorrect` rewrites of container content cannot shift positions out from under the detection.
- When the stop token is detected, the incoming chunk is trimmed before it is written, so discarded text never reaches the displayed content. If the token arrives split across chunks, its leading characters that were already written are removed from both `FullContent` and `DynamicContent` (tolerating the dynamic/static content split).
- The streaming task is then removed and the response is processed with the same `logUsage`/`checkResponse` sequence the `"TaskFinished"` handler would have run. Any subsequently buffered chunks for the removed task are discarded, and a late-firing `"TaskFinished"` is suppressed.
- The `ForceSynchronous` path applies the same trimming to the complete response before response checking.

## Test plan

- [x] New `Tests/EmulatedStopTokens.wlt` covering: activation predicate, model ending cleanly at `/exec`, hallucinated continuation after `/exec`, stop token split across several chunks, responses with no tool calls, multi-round conversations with completed tool calls in the container (including parser integration), and pass-through when emulation is disabled
- [x] `Tests/AutoCorrect.wlt`, `Tests/Citations.wlt`, and `Tests/CodeCheck.wlt` still pass
- [x] `CodeInspector` reports no new issues for `SendChat.wl`
- [x] Manual verification against gpt-5.4 with `ToolMethod -> "Simple"` in a chat notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVgu6maKe9sfsPyEiV3cZU