### PR TITLE
Use MessageTemplate/MessageParameters so Failure message text displays properly

### DIFF
--- a/Source/Chatbook/LLMUtilities.wl
+++ b/Source/Chatbook/LLMUtilities.wl
@@ -199,16 +199,18 @@ makeInvalidResponseFailure // beginDefinition;
 makeInvalidResponseFailure[ data_List ] /; MemberQ[ data, KeyValuePattern[ "StatusCode" -> 504 ] ] := Failure[
     "InvalidResponse",
     <|
-        "Message" -> "The server is currently unavailable (504 Gateway Time-out). Please try again later.",
-        "Data"    -> data
+        "MessageTemplate"   -> "The server is currently unavailable (504 Gateway Time-out). Please try again later.",
+        "MessageParameters" -> { },
+        "Data"              -> data
     |>
 ];
 
 makeInvalidResponseFailure[ data_List ] := Failure[
     "InvalidResponse",
     <|
-        "Message" -> "The server returned an invalid response. Please try again later.",
-        "Data"    -> data
+        "MessageTemplate"   -> "The server returned an invalid response. Please try again later.",
+        "MessageParameters" -> { },
+        "Data"              -> data
     |>
 ];
 

--- a/Source/Chatbook/Tools/Common.wl
+++ b/Source/Chatbook/Tools/Common.wl
@@ -757,7 +757,16 @@ toolRequestParser[ content_String ] := Enclose[
                          ];
 
         If[ FailureQ @ params,
-            Throw @ { callPosition, Failure[ "InvalidJSON", <| "Message" -> makeJSONFailureMessage @ bag |> ] }
+            Throw @ {
+                callPosition,
+                Failure[
+                    "InvalidJSON",
+                    <|
+                        "MessageTemplate"   -> makeJSONFailureMessage @ bag,
+                        "MessageParameters" -> { }
+                    |>
+                ]
+            }
         ];
 
         {

--- a/Source/Chatbook/Tools/DefaultToolDefinitions/NotebookEditor.wl
+++ b/Source/Chatbook/Tools/DefaultToolDefinitions/NotebookEditor.wl
@@ -12,7 +12,13 @@ Needs[ "Wolfram`Chatbook`Common`" ];
 (* $notebookEditorEnabled := TrueQ @ $WorkspaceChat || TrueQ @ $InlineChat; *)
 $notebookEditorEnabled = False;
 
-$cancelledNotebookEdit = Failure[ "Cancelled", <| "Message" -> "Proposed change was rejected by the user" |> ];
+$cancelledNotebookEdit = Failure[
+    "Cancelled",
+    <|
+        "MessageTemplate"   -> "Proposed change was rejected by the user",
+        "MessageParameters" -> { }
+    |>
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
## Summary

Several `Failure` objects in Chatbook stored their user-facing text under the `"Message"` key. However, the `Failure[...]["Message"]` accessor ignores that key and instead returns the generic fallback text `"A failure of type \"...\" occurred."`, so the intended error message was never displayed.

```wl
In[1]:= Failure["MyTag", <|"Message" -> "The message text"|>]["Message"]
Out[1]= "A failure of type \"MyTag\" occurred."

In[2]:= Failure["MyTag", <|"MessageTemplate" -> "The message text", "MessageParameters" -> {}|>]["Message"]
Out[2]= "The message text"
```

This PR switches the affected failures to use `"MessageTemplate"` / `"MessageParameters"` so the intended message text is returned:

- **`LLMUtilities.wl`** — `InvalidResponse` failures (504 gateway timeout + generic invalid response)
- **`Tools/Common.wl`** — `InvalidJSON` failure
- **`Tools/DefaultToolDefinitions/NotebookEditor.wl`** — `Cancelled` failure

Resolves internal issue **477301**.

## Test plan

- [ ] `Failure[...]["Message"]` on each affected failure returns the intended text rather than the generic `"A failure of type ... occurred."` fallback.
- [ ] Trigger an invalid/504 server response and confirm the surfaced error message reads correctly.
- [ ] Trigger an invalid-JSON tool request and confirm the parse-failure message is displayed.
- [ ] Reject a proposed notebook edit and confirm the cancellation message is displayed.
- [ ] Existing test suite passes.
