### PR TITLE
Fix escape handling and documentation link rendering in inline code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,9 +129,11 @@ The Chatbook notebook stylesheet (`FrontEnd/StyleSheets/Chatbook.nb`) is generat
 - Pattern variables use `$$` prefix for reusable patterns (e.g., `$$chatInputStyle`, `$$string`)
 - Build scripts use ``Wolfram`PacletCICD` `` for CI/CD utilities
 
-## Testing
+## Writing and Running Tests
 
-Tests are in `Tests/` using Wolfram's `VerificationTest` framework. Tests require a FrontEnd (`UsingFrontEnd`) since Chatbook is a notebook-based tool. Test utilities in `Tests/Common.wl` provide `WithTestNotebook`, `CreateTestChatNotebook`, and `CreateChatCells` helpers.
+Use the TestReport MCP tool to run tests.
+
+Always review [testing.md](docs/testing.md) for detailed instructions before modifying or adding tests.
 
 ## CI/CD
 
@@ -169,3 +171,7 @@ wolframscript -code 'Print[1 + 1]'
 ```
 
 Both of these will evaluate the code in an entirely separate process.
+
+Note: To print input form from wolframscript, use `Print[ToString[expr, InputForm]]`.
+
+You only need to use this wolframscript fallback if you're certain that your changes will affect the tools, or if the tools stop working as expected. The WolframLanguageEvaluator tool is designed to produce better output for AI than wolframscript.

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -2665,6 +2665,9 @@ makeInlineCodeCell // beginDefinition;
 makeInlineCodeCell[ s_String? systemNameQ ] :=
     hyperlink[ s, "paclet:ref/" <> Last @ StringSplit[ s, "`" ] ];
 
+makeInlineCodeCell[ refLink_String ] /; StringMatchQ[ refLink, "[" ~~ name__ ~~ "](paclet:ref/" ~~ name__ ~~ ")" ] :=
+    formatTextString @ refLink;
+
 makeInlineCodeCell[ code_String /; almostCertainlyWLCodeQ[ code, True ] ] :=
     makeInlineWL @ code;
 

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -366,10 +366,10 @@ makeResultCell0[ codeBlockCell[ language_String, code_String ] ] :=
     ];
 
 makeResultCell0[ inlineCodeCell[ code_String? almostCertainlyWLCodeQ ] ] :=
-    makeInlineWL @ code;
+    makeInlineWL @ StringReplace[ code, $mdUnescapeRules ];
 
 makeResultCell0[ inlineCodeCell[ code_String ] ] := ReplaceAll[
-    makeInlineCodeCell @ code,
+    makeInlineCodeCell @ StringReplace[ code, $mdUnescapeRules ],
     "\[FreeformPrompt]" :> RuleCondition @ $freeformPromptBox
 ];
 

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -68,3 +68,65 @@ VerificationTest[
     SameTest -> MatchQ,
     TestID   -> "Markdown-Escaped-Dollar@@Tests/Formatting.wlt:65,1-70,2"
 ]
+
+(* Escapes have to be restored before inline code is formatted. Otherwise the escape sentinel is still
+   embedded in the string when the symbol name is looked up, so the code renders as ordinary inline code
+   instead of resolving to a documentation link: *)
+VerificationTest[
+    FormatChatOutput[ "Try `\\$Failed` next" ],
+    RawBoxes @ Cell @ TextData @ {
+        "Try ",
+        Cell @ BoxData @ TemplateBox[ { "$Failed", "paclet:ref/$Failed", _String }, "TextRefLink" ],
+        " next"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Markdown-Escaped-Dollar-In-Inline-Code@@Tests/Formatting.wlt:75,1-84,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Inline Documentation Links*)
+
+(* Models sometimes wrap a documentation link in backticks. The link is what was meant, so it renders as a
+   link rather than as code displaying the markdown verbatim: *)
+VerificationTest[
+    FormatChatOutput[ "See `[Table](paclet:ref/Table)` for details" ],
+    RawBoxes @ Cell @ TextData @ {
+        "See ",
+        Cell @ BoxData @ TemplateBox[ { "Table", "paclet:ref/Table", _String }, "TextRefLink" ],
+        " for details"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Inline-Code-Ref-Link@@Tests/Formatting.wlt:92,1-101,2"
+]
+
+(* The same holds when the symbol name inside the link was escaped: *)
+VerificationTest[
+    FormatChatOutput[ "See `[\\$Failed](paclet:ref/\\$Failed)` for details" ],
+    RawBoxes @ Cell @ TextData @ {
+        "See ",
+        Cell @ BoxData @ TemplateBox[ { "$Failed", "paclet:ref/$Failed", _String }, "TextRefLink" ],
+        " for details"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Inline-Code-Ref-Link-Escaped-Name@@Tests/Formatting.wlt:104,1-113,2"
+]
+
+(* Only a self-referential link is rewritten this way. A label that disagrees with the reference carries
+   information that the link alone would lose, so it stays as code: *)
+VerificationTest[
+    FormatChatOutput[ "See `[Foo](paclet:ref/Bar)` for details" ],
+    RawBoxes @ Cell @ TextData @ {
+        "See ",
+        Cell[
+            BoxData @ TemplateBox[
+                { Cell[ "[Foo](paclet:ref/Bar)", Background -> None ] },
+                "ChatCodeInlineTemplate"
+            ],
+            "ChatCodeActive"
+        ],
+        " for details"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Inline-Code-Ref-Link-Mismatched-Name@@Tests/Formatting.wlt:117,1-132,2"
+]

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,97 @@
+# Writing and Running Tests
+
+This guide covers how to write and run tests for Chatbook.
+
+## Test File Format
+
+Tests use `VerificationTest` with the following format:
+
+```wl
+VerificationTest[
+    input,
+    expected,
+    SameTest -> MatchQ,
+    TestID   -> "AnAppropriateTestID"
+]
+```
+
+You can optionally include expected messages:
+
+```wl
+VerificationTest[
+    input,
+    expected,
+    { Chatbook::Tag, ... },
+    SameTest -> MatchQ,
+    TestID   -> "AnAppropriateTestID"
+]
+```
+
+### Creating New Test Files
+
+Always start new test files with the following boilerplate:
+
+```wl
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`ChatbookTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`Chatbook`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Name of First Section*)
+```
+
+The first test defines some helper functions and ensures that the paclet is loaded from the correct directory. The second test puts the main context into scope.
+
+## TestID Conventions
+
+- Every test should have a `TestID` specification
+- If the test corresponds to a GitHub issue, you should include the issue number in the test ID, e.g. `"AnAppropriateTestID-GH#123"`
+- Do not manually write the trailing `@@path/to/file.wlt:l,c` suffix
+- This location suffix is automatically generated on commit by `Scripts/FormatFiles.wls`
+
+To enable automatic TestID annotation, configure the git hook:
+
+```bash
+git config --local core.hooksPath Scripts/.githooks
+```
+
+## Running Tests with the TestReport MCP Tool
+
+If you're using an AI coding agent with the Wolfram MCP server, you can run tests using the `TestReport` tool on the `Tests/` directory.
+
+## Running Tests with `wolframscript`
+
+> Note: Only use `wolframscript` for running tests if the TestReport MCP tool is not available.
+
+Run all tests:
+
+```bash
+wolframscript -f Scripts/TestPaclet.wls
+```
+
+## Unit Tests for Private Symbols
+
+You can write unit tests for private symbols. Suppress linting errors by wrapping the test file content:
+
+```wl
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* Your tests here *)
+
+(* :!CodeAnalysis::EndBlock:: *)
+```


### PR DESCRIPTION
## Summary

Two small fixes to how chat output formats inline code, plus regression tests and developer-docs updates:

- **Restore markdown escapes before formatting inline code.** During parsing, escaped characters (e.g. `\$`) are replaced with entity sentinels, but inline code cells were formatted from the raw string, so backtick-quoted content like `` `\$Failed` `` rendered the sentinel instead of the literal character — and symbol names containing escaped characters failed to resolve to documentation links.
- **Render documentation links wrapped in inline code as hyperlinks.** Models sometimes emit a ref link inside backticks (e.g. `` `[Table](paclet:ref/Table)` ``), which previously displayed the markdown verbatim as code. A self-referential ref link that makes up the entire inline code content is now formatted as a hyperlink instead. A link whose label disagrees with its reference is deliberately left as code, since rewriting it would discard the label.
- Adds regression tests covering both fixes to `Tests/Formatting.wlt` (all three fail against the previous code), including one pinning the mismatched-label boundary case.
- Updates `AGENTS.md` and `docs/testing.md` with more detailed supplemental test instructions and a wolframscript hint.

## Test plan

- [x] New regression tests in `Tests/Formatting.wlt`:
  - `Markdown-Escaped-Dollar-In-Inline-Code` — an escaped symbol name in inline code still resolves to a documentation link
  - `Inline-Code-Ref-Link` — a ref link wrapped in backticks renders as a `TextRefLink`
  - `Inline-Code-Ref-Link-Escaped-Name` — same, with an escaped symbol name inside the link
  - `Inline-Code-Ref-Link-Mismatched-Name` — a label that disagrees with the reference stays as inline code
- [x] Existing `Tests/Formatting.wlt` tests still pass
- [ ] CI build + full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PV1ihBryeJv7LSFNQ3UeCn