### PR TITLE
Add AgentTools application data directory to sandbox $defaultWritePaths

### DIFF
--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -624,6 +624,7 @@ $defaultWritePaths := $defaultWritePaths = Select[
         FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Parallel", "Preferences" },
         FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Credentials" },
         FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Astro" },
+        FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Wolfram", "AgentTools" },
         FileNameJoin @ { $UserBaseDirectory, "Knowledgebase" },
         FileNameJoin @ { $UserBaseDirectory, "Logs" },
         FileNameJoin @ { ExpandFileName @ URL @ $LocalBase, "Resources" }

--- a/Tests/Sandbox.wlt
+++ b/Tests/Sandbox.wlt
@@ -1,0 +1,61 @@
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Initialization*)
+VerificationTest[
+    Needs[ "Wolfram`ChatbookTests`", FileNameJoin @ { DirectoryName @ $TestFileName, "Common.wl" } ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "GetDefinitions@@Tests/Sandbox.wlt:4,1-9,2"
+]
+
+VerificationTest[
+    Needs[ "Wolfram`Chatbook`" ],
+    Null,
+    SameTest -> MatchQ,
+    TestID   -> "LoadContext@@Tests/Sandbox.wlt:11,1-16,2"
+]
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Default Sandbox Paths*)
+
+(* AgentTools persists evaluator session state from the sandbox kernel to this directory: *)
+VerificationTest[
+    MemberQ[
+        Wolfram`Chatbook`Sandbox`Private`$defaultWritePaths,
+        FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Wolfram", "AgentTools" }
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "DefaultWritePaths-AgentTools-GH#1595@@Tests/Sandbox.wlt:26,1-34,2"
+]
+
+VerificationTest[
+    MemberQ[
+        Wolfram`Chatbook`Sandbox`Private`makeWritePaths @ Automatic,
+        FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Wolfram", "AgentTools" }
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "MakeWritePaths-Automatic-AgentTools-GH#1595@@Tests/Sandbox.wlt:36,1-44,2"
+]
+
+(* Session files are read back via Get, which relies on read access to all of ApplicationData. *)
+(* Initializing $defaultReadPaths mentions the front end, which is not available when running tests: *)
+VerificationTest[
+    Quiet[
+        MemberQ[
+            Wolfram`Chatbook`Sandbox`Private`$defaultReadPaths,
+            FileNameJoin @ { $UserBaseDirectory, "ApplicationData" }
+        ],
+        FrontEndObject::notavail
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "DefaultReadPaths-ApplicationData-GH#1595@@Tests/Sandbox.wlt:48,1-59,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)


### PR DESCRIPTION
## Summary

Adds the AgentTools application data directory to `$defaultWritePaths` in `Source/Chatbook/Sandbox.wl`:

```wl
FileNameJoin @ { $UserBaseDirectory, "ApplicationData", "Wolfram", "AgentTools" }
```

AgentTools persists evaluator session state from the sandbox kernel (`"Method" -> "Local"`) to `.../ApplicationData/Wolfram/AgentTools/Sessions/<id>.mx` via `DumpSave` + `RenameFile`. Those writes were silently blocked because the directory was not in the default write whitelist, forcing AgentTools to re-write session files from the controlling kernel. With this change the sandbox kernel can persist session state directly, keeping the save atomic within one kernel.

Closes #1595

## Testing

- New `Tests/Sandbox.wlt` verifies the AgentTools directory is in `$defaultWritePaths` (both directly and via `makeWritePaths @ Automatic`) and that ApplicationData remains in `$defaultReadPaths`, which reading session files back relies on. All pass, along with the existing `Tests/WolframLanguageToolEvaluate.wlt` suite (49/49).
- Verified end-to-end in a separate kernel: with this change, `WolframLanguageToolEvaluate` with `Method -> "Local"` successfully performs the `DumpSave` + `RenameFile` flow into `AgentTools/Sessions` and the controlling kernel reads the saved data back, while writes to a non-whitelisted sibling directory remain blocked.
- `CodeInspector` reports no issues on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2fiK5uAk4U25YcSLaXj29