### PR TITLE
Resume automatic version increment once the release artifact exists

### DIFF
--- a/Scripts/IncrementPacletVersion.wls
+++ b/Scripts/IncrementPacletVersion.wls
@@ -12,6 +12,82 @@ Needs[ "Wolfram`PacletCICD`" -> "cicd`" ];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*githubRepository*)
+githubRepository[ dir_ ] := Enclose[
+    Module[ { env, url },
+        env = Environment[ "GITHUB_REPOSITORY" ];
+        If[ StringQ @ env,
+            env,
+            url = ConfirmBy[ gitCommand[ { "remote", "get-url", "origin" }, dir ], StringQ, "OriginURL" ];
+            ConfirmBy[
+                First[
+                    StringCases[
+                        url,
+                        "github.com" ~~ (":" | "/") ~~ owner: Except[ "/" ].. ~~ "/" ~~ name: Except[ "/" ].. :>
+                            owner <> "/" <> StringDelete[ name, ".git" ~~ EndOfString ]
+                    ],
+                    $Failed
+                ],
+                StringQ,
+                "Repository"
+            ]
+        ]
+    ],
+    $Failed &
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*releaseAssetURL*)
+releaseAssetURL[ dir_, version_ ] := Enclose[
+    Module[ { repo, name, file },
+        repo = ConfirmBy[ githubRepository @ dir, StringQ, "Repository" ];
+        name = ConfirmBy[ PacletObject[ Flatten @ File @ dir ][ "Name" ], StringQ, "PacletName" ];
+        file = StringReplace[ name, "/" -> "__" ] <> "-" <> version <> ".paclet";
+        TemplateApply[ "https://github.com/`1`/releases/download/v`2`/`3`", { repo, version, file } ]
+    ],
+    $Failed &
+];
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
+(*versionReleasedQ*)
+$releaseCheckTimeout = 30;
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
+versionReleasedQ[ dir_, version_ ] :=
+    versionReleasedQ[ dir, version, releaseAssetURL[ dir, version ] ];
+
+versionReleasedQ[ _, _, url_String ] :=
+    Module[ { status },
+        status = Quiet @ URLRead[
+            HTTPRequest[ url, <| "Method" -> "HEAD" |> ],
+            "StatusCode",
+            FollowRedirects -> True, (* Avoids a 302 response *)
+            TimeConstraint  -> $releaseCheckTimeout
+        ];
+        Which[
+            status === 200,
+                Print[ "Release artifact found: ", url ];
+                True,
+            status === 404,
+                Print[ "Release artifact not found: ", url ];
+                False,
+            True,
+                Print[ "::warning::Release artifact check failed (", ToString[ status, InputForm ], "): ", url ];
+                False
+        ]
+    ];
+
+versionReleasedQ[ _, version_, _ ] := (
+    Print[ "::warning::Unable to determine release artifact URL for version ", version, "." ];
+    False
+);
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*incrementPacletVersion*)
 (* :!CodeAnalysis::BeginBlock:: *)
 (* :!CodeAnalysis::Disable::SuspiciousSessionSymbol:: *)
@@ -25,7 +101,7 @@ incrementPacletVersion[ dir_ ] := Enclose[
         string  = cs[ ReadString @ file, "ReadString" ];
         version = cs[ PacletObject[ Flatten @ File @ dir ][ "Version" ], "Version" ];
 
-        If[ StringEndsQ[ version, "." ~~ "0".. ~~ EndOfString ],
+        If[ StringEndsQ[ version, "." ~~ "0".. ~~ EndOfString ] && ! TrueQ @ versionReleasedQ[ dir, version ],
             Print[ "Skipping paclet version update: ", version ];
             Throw @ version
         ];


### PR DESCRIPTION
## Summary

Ports WolframResearch/AgentTools#226 to Chatbook, which uses the same version increment scheme.

The IncrementPacletVersion workflow skips versions ending in `.0`, since that's the convention for a manually-set release version that shouldn't be bumped before the Release action runs. However, this meant the version had to be incremented manually after each release to get auto-increment working again.

This change makes the skip conditional on whether the release has actually been published. When the version ends in `.0`, the script now sends a HEAD request for the corresponding release artifact (`https://github.com/<repo>/releases/download/v<version>/<paclet-file>.paclet`, with `FollowRedirects -> True` made explicit since these URLs respond with a 302 to the CDN):

- **200** → the release exists, so auto-increment resumes (e.g. `2.7.0` → `2.7.1`)
- **404** → not yet released, so the version is left alone (previous behavior)
- **anything else** (network failure, unexpected status, undeterminable URL) → logs a `::warning::` annotation and falls back to skipping, so a transient GitHub problem can never wrongly bump a pre-release version or fail the workflow; the check self-heals on the next push to main

Checking the artifact rather than the tag or the REST API means no `GITHUB_TOKEN` plumbing (the download URL is served from the releases CDN, unlike rate-limited unauthenticated `api.github.com` calls), and the artifact's existence is the strictest "release actually completed" signal. Nothing is hard-coded: the repository comes from `GITHUB_REPOSITORY` (falling back to parsing the `origin` remote URL for local runs) and the asset name is derived from the paclet's `Name` and version. Non-`.0` versions never make a network call, and no workflow YAML changes are required.

Note: since `PacletInfo.wl` is currently at 2.7.0 and [v2.7.0](https://github.com/WolframResearch/Chatbook/releases/tag/v2.7.0) is already published, the first push to main after this merges should auto-bump the version to 2.7.1.

## Test plan

- [x] Verified in a kernel session using the definitions extracted from this repo's copy of the script:
  - Repository detection returns `WolframResearch/Chatbook` via both `GITHUB_REPOSITORY` and `git remote get-url origin` parsing
  - URL construction produces `.../releases/download/v2.7.0/Wolfram__Chatbook-2.7.0.paclet`, which returns 200
  - End-to-end `incrementPacletVersion` on temp `PacletInfo.wl` copies: `2.7.0` → `2.7.1` (resume case), `2.8.0` → skipped
  - Fail-safe paths (no repository determinable, unresolvable host) warn and skip, verified on the identical AgentTools implementation
- [x] CodeInspector reports no issues for the modified script
- [ ] After merging: confirm the next push to main bumps `2.7.0` → `2.7.1` in the Increment Paclet Version workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BahTo2TcpBswpZVPSRVvJ5