### PR TITLE
Optimize RelatedWolframAlphaResults for use alongside RelatedDocumentation

### DIFF
--- a/Source/Chatbook/LLMUtilities.wl
+++ b/Source/Chatbook/LLMUtilities.wl
@@ -45,12 +45,13 @@ llmChat[ messages: $$chatMessages ] :=
     llmChat[ messages, <| |> ];
 
 llmChat[ messages: $$chatMessages, evaluator0_Association ] :=
-    Enclose @ Module[ { evaluator, config, auth, response },
+    Enclose @ Module[ { evaluator, stop, config, auth, response },
 
         evaluator = ConfirmBy[ resolveLLMConfiguration @ evaluator0, AssociationQ, "Evaluator" ];
+        stop = Select[ Flatten @ { evaluator[ "StopTokens" ] }, StringQ ];
 
         config = ConfirmMatch[
-            LLMConfiguration @ evaluator,
+            LLMConfiguration @ dropModelUnsupportedParameters[ Automatic, evaluator ],
             HoldPattern @ LLMConfiguration[ _Association? AssociationQ, ___ ],
             "Config"
         ];
@@ -63,7 +64,7 @@ llmChat[ messages: $$chatMessages, evaluator0_Association ] :=
 
         If[ FailureQ @ response, throwFailureToChatOutput @ response ];
 
-        response
+        stopTokenTrim[ response, stop ]
     ];
 
 llmChat // endDefinition;
@@ -121,14 +122,15 @@ llmSynthesizeSubmit[ prompt: $$llmPrompt, callback_ ] :=
     llmSynthesizeSubmit[ prompt, <| |>, callback ];
 
 llmSynthesizeSubmit[ prompt0: $$llmPrompt, evaluator0_Association, callback_ ] := Enclose[
-    Module[ { evaluator, prompt, messages, config, chunks, allowEmpty, handlers, keys, auth },
+    Module[ { evaluator, prompt, messages, config, chunks, stop, allowEmpty, handlers, keys, auth },
 
         evaluator  = ConfirmBy[ resolveLLMConfiguration @ evaluator0, AssociationQ, "Evaluator" ];
         prompt     = ConfirmMatch[ truncatePrompt[ prompt0, evaluator ], $$llmPrompt, "Prompt" ];
         messages   = { <| "Role" -> "User", "Content" -> prompt |> };
-        config     = LLMConfiguration @ evaluator;
+        config     = LLMConfiguration @ dropModelUnsupportedParameters[ Automatic, evaluator ];
         chunks     = Internal`Bag[ ];
-        allowEmpty = MatchQ[ Flatten @ { evaluator[ "StopTokens" ] }, { __String } ];
+        stop       = Select[ Flatten @ { evaluator[ "StopTokens" ] }, StringQ ];
+        allowEmpty = Length @ stop > 0;
 
         handlers = <|
             "BodyChunkReceived" -> Function[
@@ -141,7 +143,7 @@ llmSynthesizeSubmit[ prompt0: $$llmPrompt, evaluator0_Association, callback_ ] :
                     strings = extractBodyChunks @ data;
                     Which[
                         MatchQ[ strings, { __String } ] || (allowEmpty && strings === { }),
-                            With[ { s = StringJoin @ strings }, callback[ s, #1 ] ],
+                            With[ { s = stopTokenTrim[ strings, stop ] }, callback[ s, #1 ] ],
                         FailureQ @ strings,
                             callback[ strings, #1 ],
                         True,
@@ -170,6 +172,25 @@ llmSynthesizeSubmit[ prompt0: $$llmPrompt, evaluator0_Association, callback_ ] :
 ];
 
 llmSynthesizeSubmit // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*stopTokenTrim*)
+(* For models that do not support stop tokens, we manually trim the content to emulate stop token behavior *)
+stopTokenTrim // beginDefinition;
+
+stopTokenTrim[ content_String, { } ] := content;
+
+stopTokenTrim[ content_String, stop: { __String } ] :=
+    StringDelete[ content, stop ~~ ___ ~~ EndOfString ];
+
+stopTokenTrim[ content: { ___String }, stop_ ] :=
+    stopTokenTrim[ StringJoin @ content, stop ];
+
+stopTokenTrim[ as: KeyValuePattern[ "Content" -> content_ ], stop_ ] :=
+    <| as, "Content" -> stopTokenTrim[ content, stop ] |>;
+
+stopTokenTrim // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
+++ b/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
@@ -24,6 +24,7 @@ $instructions       = None;
 $reinterpret        = False;
 $showSteps          = True;
 $includeWLResults  := TrueQ @ toolSelectedQ[ "WolframLanguageEvaluator" ];
+$docsProvided       = False;
 
 $timeouts = <|
     "URLSubmit"   -> 25,
@@ -93,18 +94,19 @@ Chatbook::UnhandledWolframAlphaXMLTag = "Unhandled Wolfram Alpha XML tag: ``";
 (*RelatedWolframAlphaResults*)
 RelatedWolframAlphaResults // beginDefinition;
 RelatedWolframAlphaResults // Options = {
-    "AppID"             -> Automatic,
-    "CacheResults"      -> False,
-    "Debug"             -> False,
-    "IncludeWLResults"  -> Automatic,
-    "Instructions"      -> None,
-    "LLMEvaluator"      -> Automatic,
-    "MaxItems"          -> Automatic,
-    "PromptHeader"      -> Automatic,
-    "RandomQueryCount"  -> Automatic,
-    "Reinterpret"       -> False,
-    "RelatedQueryCount" -> Automatic,
-    "SampleQueryCount"  -> Automatic
+    "AppID"                 -> Automatic,
+    "CacheResults"          -> False,
+    "Debug"                 -> False,
+    "DocumentationProvided" -> False, (* Set to True if RelatedDocumentation is also being provided separately *)
+    "IncludeWLResults"      -> Automatic,
+    "Instructions"          -> None,
+    "LLMEvaluator"          -> Automatic,
+    "MaxItems"              -> Automatic,
+    "PromptHeader"          -> Automatic,
+    "RandomQueryCount"      -> Automatic,
+    "Reinterpret"           -> False,
+    "RelatedQueryCount"     -> Automatic,
+    "SampleQueryCount"      -> Automatic
 };
 
 (* ::**************************************************************************************************************:: *)
@@ -159,12 +161,14 @@ RelatedWolframAlphaResults[ prompt_, "Prompt", n_Integer, opts: OptionsPattern[ 
             $generatorLLMConfig = Replace[ OptionValue[ "LLMEvaluator" ], $$unspecified :> $generatorLLMConfig ],
             $usePromptHeader    = Replace[ OptionValue[ "PromptHeader" ], $$unspecified :> $usePromptHeader ],
             $includeWLResults   = Replace[ OptionValue[ "IncludeWLResults" ], $$unspecified :> $includeWLResults ],
+            $docsProvided       = Replace[ OptionValue[ "DocumentationProvided" ], $$unspecified :> $docsProvided ],
             $instructions       = OptionValue[ "Instructions" ],
             $maxItems           = n,
             $sampleQueries      = None,
             $sampleQueryCount   = Replace[ OptionValue[ "SampleQueryCount" ], $$unspecified|None :> 0 ],
             $reinterpret        = Replace[ OptionValue[ "Reinterpret" ], $$unspecified :> $reinterpret ]
         },
+        If[ $docsProvided, $includeWLResults = True ];
         relatedWolframAlphaResultsPrompt[
             ensureChatMessages @ prompt,
             n,
@@ -200,12 +204,14 @@ RelatedWolframAlphaResults[ prompt_, "FullData", n_Integer, opts: OptionsPattern
             $generatorLLMConfig = Replace[ OptionValue[ "LLMEvaluator" ], $$unspecified :> $generatorLLMConfig ],
             $usePromptHeader    = Replace[ OptionValue[ "PromptHeader" ], $$unspecified :> $usePromptHeader ],
             $includeWLResults   = Replace[ OptionValue[ "IncludeWLResults" ], $$unspecified :> $includeWLResults ],
+            $docsProvided       = Replace[ OptionValue[ "DocumentationProvided" ], $$unspecified :> $docsProvided ],
             $instructions       = OptionValue[ "Instructions" ],
             $maxItems           = n,
             $sampleQueries      = None,
             $sampleQueryCount   = Replace[ OptionValue[ "SampleQueryCount" ], $$unspecified|None :> All ],
             $reinterpret        = Replace[ OptionValue[ "Reinterpret" ], $$unspecified :> $reinterpret ]
         },
+        If[ $docsProvided, $includeWLResults = True ];
         relatedWolframAlphaResultsFullData[
             ensureChatMessages @ prompt,
             n,
@@ -254,7 +260,10 @@ Here are some examples of valid Wolfram Alpha queries to give you a sense of wha
 Reply with up to `MaxItems` queries each on a separate line and nothing else. \
 Reply with [NONE] if the user's prompt is completely unrelated to anything computational or knowledge-based, \
 e.g. casual conversation.
-Reply with [WL] if the user's prompt would be better answered with Wolfram Language documentation instead.
+Reply with [WL] if the user's prompt would be better answered with Wolfram documentation instead, e.g.
+* asking *how* to do something
+* concerns Wolfram Language functions, syntax, or other programming concepts
+* explicitly asking about Wolfram Language or other Wolfram products
 
 `Instructions`" ];
 
@@ -379,6 +388,7 @@ makeMessagePairs // endDefinition;
 (*usingDocumentationQ*)
 usingDocumentationQ // beginDefinition;
 usingDocumentationQ[ ] := usingDocumentationQ @ $ChatHandlerData[ "ChatNotebookSettings", "PromptGenerators" ];
+usingDocumentationQ[ _ ] /; $docsProvided := True;
 usingDocumentationQ[ generators_List ] := AnyTrue[ generators, usingDocumentationQ ];
 usingDocumentationQ[ HoldPattern @ LLMPromptGenerator[ as_, ___ ] ] := usingDocumentationQ @ as;
 usingDocumentationQ[ KeyValuePattern[ "Name" -> name_String ] ] := usingDocumentationQ @ name;
@@ -1060,7 +1070,7 @@ getGeoIPRule[ ] :=
                     ], "," ]
         ,
         True,
-        (* I could imagine choosing an external IPv4 address via  
+        (* I could imagine choosing an external IPv4 address via
              "ip" -> SelectFirst[$MachineAddresses, StringFreeQ[#, "::"] && !StringStartsQ[#, "10." | "192.168"]&]
            but I can also imagine that would always be Missing because the router assigns an internal address.
            In this case, the Alpha server can use GeoIP based on the remote IPAddress *)

--- a/Source/Chatbook/Settings.wl
+++ b/Source/Chatbook/Settings.wl
@@ -635,6 +635,14 @@ dropModelUnsupportedParameters[ model_Association, config_Association ] := Enclo
     throwInternalFailure
 ];
 
+dropModelUnsupportedParameters[ Automatic, config_Association ] :=
+    dropModelUnsupportedParameters[ config[ "Model" ], config ];
+
+dropModelUnsupportedParameters[ model0: Except[ _Association ], config_Association ] :=
+    With[ { model = resolveFullModelSpec @ model0 },
+        dropModelUnsupportedParameters[ model, config ] /; AssociationQ @ model
+    ];
+
 dropModelUnsupportedParameters // endDefinition;
 
 (* ::**************************************************************************************************************:: *)

--- a/Tests/EmulatedStopTokens.wlt
+++ b/Tests/EmulatedStopTokens.wlt
@@ -345,4 +345,135 @@ VerificationTest[
     TestID   -> "ApplyEmulatedStopTokens-PassThrough@@Tests/EmulatedStopTokens.wlt:316,1-346,2"
 ]
 
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*stopTokenTrim*)
+
+(* llmChat and llmSynthesizeSubmit drop the server-side stop parameter for models that do not support it
+   (via dropModelUnsupportedParameters) and instead trim the generated content client-side with stopTokenTrim. *)
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ "text with [WL] inside", { } ],
+    "text with [WL] inside",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-NoStopTokens@@Tests/EmulatedStopTokens.wlt:355,1-360,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[
+        "query one\nquery two\n[NONE] extra",
+        { "[NONE]", "[WL]" }
+    ],
+    "query one\nquery two\n",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-TrimsToEnd@@Tests/EmulatedStopTokens.wlt:362,1-370,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ "a[WL]b[WL]c", { "[NONE]", "[WL]" } ],
+    "a",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-FirstOccurrence@@Tests/EmulatedStopTokens.wlt:372,1-377,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ "[WL] use documentation instead", { "[NONE]", "[WL]" } ],
+    "",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-EntireResponse@@Tests/EmulatedStopTokens.wlt:379,1-384,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ "123456789th prime", { "[NONE]", "[WL]" } ],
+    "123456789th prime",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-NoMatch@@Tests/EmulatedStopTokens.wlt:386,1-391,2"
+]
+
+(* A stop token may arrive split across several streamed chunks: *)
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ { "queries", "\n[NO", "NE] extra" }, { "[NONE]", "[WL]" } ],
+    "queries\n",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-SplitChunks@@Tests/EmulatedStopTokens.wlt:394,1-399,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[ { }, { "[NONE]", "[WL]" } ],
+    "",
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-EmptyChunks@@Tests/EmulatedStopTokens.wlt:401,1-406,2"
+]
+
+(* llmChat responses are associations with a "Content" key; other keys pass through unchanged: *)
+VerificationTest[
+    Wolfram`Chatbook`LLMUtilities`Private`stopTokenTrim[
+        <| "Content" -> "q1\n[WL] junk", "ToolRequests" -> { } |>,
+        { "[NONE]", "[WL]" }
+    ],
+    <| "Content" -> "q1\n", "ToolRequests" -> { } |>,
+    SameTest -> MatchQ,
+    TestID   -> "StopTokenTrim-Association@@Tests/EmulatedStopTokens.wlt:409,1-417,2"
+]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*dropModelUnsupportedParameters*)
+
+(* gpt-5 does not support stop tokens, so the parameter is dropped before creating the LLMConfiguration: *)
+VerificationTest[
+    Wolfram`Chatbook`Common`dropModelUnsupportedParameters[
+        Automatic,
+        <|
+            "Model"      -> <| "Service" -> "OpenAI", "Name" -> "gpt-5" |>,
+            "StopTokens" -> { "[NONE]" },
+            "MaxTokens"  -> 250
+        |>
+    ],
+    <| "Model" -> <| "Service" -> "OpenAI", "Name" -> "gpt-5" |>, "MaxTokens" -> 250 |>,
+    SameTest -> MatchQ,
+    TestID   -> "DropModelUnsupportedParameters-Automatic-Unsupported@@Tests/EmulatedStopTokens.wlt:424,1-436,2"
+]
+
+(* gpt-4o supports stop tokens, so the settings are unchanged: *)
+VerificationTest[
+    Wolfram`Chatbook`Common`dropModelUnsupportedParameters[
+        Automatic,
+        <|
+            "Model"      -> <| "Service" -> "OpenAI", "Name" -> "gpt-4o" |>,
+            "StopTokens" -> { "[NONE]" },
+            "MaxTokens"  -> 250
+        |>
+    ],
+    <|
+        "Model"      -> <| "Service" -> "OpenAI", "Name" -> "gpt-4o" |>,
+        "StopTokens" -> { "[NONE]" },
+        "MaxTokens"  -> 250
+    |>,
+    SameTest -> MatchQ,
+    TestID   -> "DropModelUnsupportedParameters-Automatic-Supported@@Tests/EmulatedStopTokens.wlt:439,1-455,2"
+]
+
+(* Shorthand model specifications are resolved with resolveFullModelSpec: *)
+VerificationTest[
+    Wolfram`Chatbook`Common`dropModelUnsupportedParameters[
+        { "OpenAI", "gpt-5" },
+        <| "StopTokens" -> { "[NONE]" }, "MaxTokens" -> 250 |>
+    ],
+    <| "MaxTokens" -> 250 |>,
+    SameTest -> MatchQ,
+    TestID   -> "DropModelUnsupportedParameters-ShorthandModelSpec@@Tests/EmulatedStopTokens.wlt:458,1-466,2"
+]
+
+(* Automatic also works when the config specifies its model in shorthand form: *)
+VerificationTest[
+    Wolfram`Chatbook`Common`dropModelUnsupportedParameters[
+        Automatic,
+        <| "Model" -> { "OpenAI", "o4-mini" }, "StopTokens" -> { "[NONE]" }, "Temperature" -> 0.7 |>
+    ],
+    <| "Model" -> { "OpenAI", "o4-mini" } |>,
+    SameTest -> MatchQ,
+    TestID   -> "DropModelUnsupportedParameters-Automatic-ShorthandModelSpec@@Tests/EmulatedStopTokens.wlt:469,1-477,2"
+]
+
 (* :!CodeAnalysis::EndBlock:: *)

--- a/Tests/RelatedWolframAlphaResults.wlt
+++ b/Tests/RelatedWolframAlphaResults.wlt
@@ -89,6 +89,62 @@ VerificationTest[
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)
+(*DocumentationProvided*)
+VerificationTest[
+    Lookup[ Options @ RelatedWolframAlphaResults, "DocumentationProvided" ],
+    False,
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-DocumentationProvided-Default@@Tests/RelatedWolframAlphaResults.wlt:93,1-98,2"
+]
+
+(* Prompts better answered by documentation should not generate any Wolfram Alpha queries: *)
+VerificationTest[
+    RelatedWolframAlphaResults[
+        "How do I deploy a web form to the cloud?",
+        "DocumentationProvided" -> True,
+        $defaultTestOptions
+    ],
+    "",
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-DocumentationProvided-DefersToDocs@@Tests/RelatedWolframAlphaResults.wlt:101,1-110,2"
+]
+
+(* Computational prompts still give results, which now include equivalent Wolfram Language code: *)
+VerificationTest[
+    RelatedWolframAlphaResults[
+        "What is the 1000th prime number?",
+        "DocumentationProvided" -> True,
+        $defaultTestOptions
+    ],
+    _String? (StringContainsQ[ #, ToString @ Prime[ 1000 ] ] && StringContainsQ[ #, "```wl" ] &),
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-DocumentationProvided-IncludesWLResults@@Tests/RelatedWolframAlphaResults.wlt:113,1-122,2"
+]
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* The DocumentationProvided option forces usingDocumentationQ to give True regardless of chat settings: *)
+VerificationTest[
+    Block[ { Wolfram`Chatbook`PromptGenerators`RelatedWolframAlphaResults`Private`$docsProvided = True },
+        Wolfram`Chatbook`PromptGenerators`RelatedWolframAlphaResults`Private`usingDocumentationQ[ ]
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-DocumentationProvided-UsingDocumentationQ@@Tests/RelatedWolframAlphaResults.wlt:128,1-135,2"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`PromptGenerators`RelatedWolframAlphaResults`Private`usingDocumentationQ[ ],
+    False,
+    SameTest -> MatchQ,
+    TestID   -> "RelatedWolframAlphaResults-DocumentationProvided-UsingDocumentationQ-Default@@Tests/RelatedWolframAlphaResults.wlt:137,1-142,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsection::Closed:: *)
 (*Handler Data*)
 VerificationTest[
     $ChatHandlerData = <| |>;
@@ -101,7 +157,7 @@ VerificationTest[
         "SampleQueries" -> { ___String }
     },
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframAlphaResults-HandlerData@@Tests/RelatedWolframAlphaResults.wlt:93,1-105,2"
+    TestID   -> "RelatedWolframAlphaResults-HandlerData@@Tests/RelatedWolframAlphaResults.wlt:149,1-161,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -120,5 +176,5 @@ VerificationTest[
     _Failure,
     If[ $VersionNumber >= 14.3, { }, { ServiceExecute::apierr } ],
     SameTest -> MatchQ,
-    TestID   -> "RelatedWolframAlphaResults-ErrorHandling-LLMServices@@Tests/RelatedWolframAlphaResults.wlt:112,1-124,2"
+    TestID   -> "RelatedWolframAlphaResults-ErrorHandling-LLMServices@@Tests/RelatedWolframAlphaResults.wlt:168,1-180,2"
 ]


### PR DESCRIPTION
## Summary

`RelatedWolframAlphaResults` is often used alongside `RelatedDocumentation` (e.g. in AgentTools context generation), but it had no way to know that, so prompts better answered by documentation spent several seconds making Wolfram Alpha calls that all came back as "No Results Found".

- Adds a `"DocumentationProvided"` option to `RelatedWolframAlphaResults` to indicate that `RelatedDocumentation` results are being provided separately. When set:
  - The query generator is instructed to defer prompts that are better answered by Wolfram documentation (how-to questions, Wolfram Language functions/syntax, Wolfram products), returning an empty result immediately instead of making useless Wolfram Alpha calls.
  - Wolfram Language code blocks are included in the Wolfram Alpha results that are returned.
- Emulates stop tokens for models that do not support them, fixing `RelatedWolframAlphaResults` for such models: `llmChat` and `llmSynthesizeSubmit` now drop model-unsupported parameters before building the `LLMConfiguration` and trim generated content at the first stop token client-side via the new `stopTokenTrim` helper. `dropModelUnsupportedParameters` gained overloads accepting `Automatic` or shorthand model specs, resolving the full model information from the configuration itself.

### Example

```wl
(* Before: ~6.4s spent on five Wolfram Alpha calls that all return "No Results Found" *)
In[1]:= AbsoluteTiming @ RelatedWolframAlphaResults[ "How do I deploy a web form to the cloud?" ]
Out[1]= { 6.44038, "...<result query='deploy a web form to the cloud' ...>No Results Found</result>..." }

(* After: *)
In[2]:= AbsoluteTiming @ RelatedWolframAlphaResults[ "How do I deploy a web form to the cloud?", "DocumentationProvided" -> True ]
Out[2]= { 1.57143, "" }
```

Computational prompts still give results, which now also include equivalent Wolfram Language code (e.g. `Prime[123456789]` in a `wl` code block alongside the Wolfram Alpha pods).

## Test plan

- [x] New unit tests in `Tests/EmulatedStopTokens.wlt` for `stopTokenTrim` (string, streamed chunk list, and `llmChat` response association forms, including a stop token split across chunks) and the new `dropModelUnsupportedParameters` overloads
- [x] New tests in `Tests/RelatedWolframAlphaResults.wlt` for `DocumentationProvided`: option default, empty result for documentation-style prompts, Wolfram Language code blocks in computational results, and `usingDocumentationQ` behavior
- [x] Both test files pass 38/38 locally (includes live LLM and Wolfram Alpha calls)
- [x] CodeInspector reports no issues on the modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
