### PR TITLE
Minor prompting improvements

### DIFF
--- a/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
+++ b/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
@@ -243,6 +243,7 @@ Here are some examples of valid Wolfram Alpha queries to give you a sense of wha
 `Examples`
 </examples>
 
+All queries should be written in English.
 Reply with up to `MaxItems` queries each on a separate line and nothing else. \
 Reply with [NONE] if the user's prompt is completely unrelated to anything computational or knowledge-based, \
 e.g. casual conversation.
@@ -257,6 +258,7 @@ Here are some examples of valid Wolfram Alpha queries to give you a sense of wha
 `Examples`
 </examples>
 
+All queries should be written in English.
 Reply with up to `MaxItems` queries each on a separate line and nothing else. \
 Reply with [NONE] if the user's prompt is completely unrelated to anything computational or knowledge-based, \
 e.g. casual conversation.

--- a/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
+++ b/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
@@ -266,6 +266,7 @@ Reply with [WL] if the user's prompt would be better answered with Wolfram docum
 * asking *how* to do something
 * concerns Wolfram Language functions, syntax, or other programming concepts
 * explicitly asking about Wolfram Language or other Wolfram products
+* looking for examples rather than a concrete answer
 
 `Instructions`" ];
 

--- a/Source/Chatbook/Prompting.wl
+++ b/Source/Chatbook/Prompting.wl
@@ -360,8 +360,9 @@ $basePromptComponents[ "WolframLanguageStyle" ] = "
 * Prefer modern Wolfram Language symbols and methods";
 
 $basePromptComponents[ "Placeholders" ] = "\
-* If your code needs a value that only the user can provide, represent it with ``Placeholder[\"description\"]``, \
-for example: ``data = Placeholder[\"your data\"]; doTheThing[data]``. \
+* If your code needs a value that only the user can provide, represent it with ``Placeholder[\"description\"]``. \
+For example: ``data = Placeholder[\"your data\"]; DateListPlot[data]``. \
+This will render as an inline input field that replaces itself with the user's input. \
 NEVER use a comment as a stand-in for an expression (e.g. ``data = (* your data *)``), \
 since this is invalid syntax and will not display correctly to the user.";
 

--- a/Source/Chatbook/Tools/DefaultToolDefinitions/WolframAlpha.wl
+++ b/Source/Chatbook/Tools/DefaultToolDefinitions/WolframAlpha.wl
@@ -24,7 +24,10 @@ physics, geography, history, art, astronomy, and more.
 IMPORTANT: If you need the results of multiple queries, it's important that you combine them into a single tool call \
 whenever possible to save on token usage and time.";
 
-$queryHelp = "The query (or queries) to send to Wolfram|Alpha. Separate multiple queries with tab characters (\\t).";
+$queryHelp = "\
+The query (or queries) to send to Wolfram|Alpha. \
+All queries should be written in English. \
+Separate multiple queries with tab characters (\\t).";
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsection::Closed:: *)


### PR DESCRIPTION
## Summary

Three small prompt refinements:

### Wolfram|Alpha queries in English

Both `RelatedWolframAlphaResults` prompt templates and the WolframAlpha tool's `query` parameter description now state that queries should be written in English. Without this, conversations held in another language could produce queries in that language, which Wolfram|Alpha often fails to interpret.

### Redirect example-seeking prompts to documentation

"Looking for examples rather than a concrete answer" is now listed among the `RelatedWolframAlphaResults` criteria for replying `[WL]`, so prompts asking for usage examples defer to Wolfram Language documentation lookup rather than generating Wolfram|Alpha queries.

### Clearer `Placeholder` guidance

The `"Placeholders"` base prompt component (added in #1602) now uses a realistic example (`DateListPlot[data]` instead of `doTheThing[data]`) and explains that the placeholder renders as an inline input field that replaces itself with the user's input.

## Test plan

- [x] CodeInspector clean on all three touched files (only the pre-existing FIXME warning and `\:f3a2` remark in `RelatedWolframAlphaResults.wl`, both in code untouched by this PR)
- [ ] CI build + full test suite (changes are prompt string literals only; `Tests/Prompting.wlt` covers `"Placeholders"` component inclusion)
- [ ] Spot-check that a non-English conversation produces English Wolfram|Alpha queries and that example-seeking prompts reply `[WL]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)