### PR TITLE
Export cloud sandbox session state as $CloudSessionMX

### DIFF
--- a/Source/Chatbook/Main.wl
+++ b/Source/Chatbook/Main.wl
@@ -19,6 +19,7 @@ BeginPackage[ "Wolfram`Chatbook`" ];
 `$ChatPost;
 `$ChatPre;
 `$ChatTimingData;
+`$CloudSessionMX;
 `$ContentSuggestions;
 `$CurrentChatSettings;
 `$DefaultChatHandlerFunctions;

--- a/Source/Chatbook/Sandbox.wl
+++ b/Source/Chatbook/Sandbox.wl
@@ -30,6 +30,7 @@ sp`InlinedExpression;
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
 (*Configuration*)
+$CloudSessionMX            = None;
 $SandboxKernel             = None;
 $appendURIPrompt          := toolOptionValue[ "WolframLanguageEvaluator", "AppendURIPrompt"          ];
 $includeDefinitions       := toolOptionValue[ "WolframLanguageEvaluator", "IncludeDefinitions"       ];
@@ -43,7 +44,6 @@ $hintMethod               := toolOptionValue[ "WolframLanguageEvaluator", "HintM
 $disabledHints            := toolOptionValue[ "WolframLanguageEvaluator", "DisabledHints"            ];
 $cloudEvaluatorLocation    = "/Chatbook/Tools/WolframLanguageEvaluator/Evaluate";
 $cloudLineNumber           = 1;
-$cloudSession              = None;
 $maxSandboxMessages        = 10;
 $maxMessageParameterLength = 100;
 $toolOutputPageWidth       = 100;
@@ -1132,8 +1132,8 @@ cloudSandboxEvaluate[ HoldComplete[ evaluation_ ] ] := Enclose[
                         "Body" -> {
                             "Evaluation" -> BaseEncode @ wxf,
                             "TimeConstraint" -> $sandboxEvaluationTimeout,
-                            If[ ByteArrayQ @ definitions  , "Definitions" -> BaseEncode @ definitions  , Nothing ],
-                            If[ ByteArrayQ @ $cloudSession, "SessionMX"   -> BaseEncode @ $cloudSession, Nothing ]
+                            If[ ByteArrayQ @ definitions    , "Definitions" -> BaseEncode @ definitions    , Nothing ],
+                            If[ ByteArrayQ @ $CloudSessionMX, "SessionMX"   -> BaseEncode @ $CloudSessionMX, Nothing ]
                         }
                     |>
                 ],
@@ -1171,7 +1171,7 @@ cloudSandboxEvaluate // endDefinition;
 (*setCloudSessionString*)
 setCloudSessionString // beginDefinition;
 setCloudSessionString[ KeyValuePattern[ "SessionMX" -> mx_ ] ] := setCloudSessionString @ mx;
-setCloudSessionString[ mx_ByteArray ] := $cloudSession = mx;
+setCloudSessionString[ mx_ByteArray ] := $CloudSessionMX = mx;
 setCloudSessionString[ s_String ] := setCloudSessionString @ ByteArray @ s;
 setCloudSessionString // endDefinition;
 


### PR DESCRIPTION
## Summary

- Rename the private `$cloudSession` symbol to `$CloudSessionMX` and declare it in `Main.wl`, adding it to the public ``Wolfram`Chatbook` `` API surface
- The symbol holds the serialized (MX) session state for the cloud sandbox evaluator, so exporting it makes that state accessible outside the package (e.g. for inspection or resetting the cloud session)
- Update all usages in `Sandbox.wl` (`cloudSandboxEvaluate` request body and `setCloudSessionString`); no references to the old private name remain

## Test plan

- [ ] Load the paclet from source and verify the symbol lands in the correct context: ``Names["Wolfram`Chatbook`$CloudSessionMX"]``
- [ ] Verify default value is `None` before any cloud sandbox evaluation
- [ ] Run a cloud sandbox evaluation and confirm session MX round-trips: `$CloudSessionMX` is populated after evaluation and sent as `"SessionMX"` on subsequent requests
- [ ] CI build + test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)