### PR TITLE
Handle unrecognized XML tags in parsePodContent

### DIFF
--- a/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
+++ b/Source/Chatbook/PromptGenerators/RelatedWolframAlphaResults.wl
@@ -67,6 +67,7 @@ $$ignoredXMLTag = Alternatives[
     "sources",
     "states",
     "stepbystepcontenttype",
+    "subpodcustomizationdata",
     "userinfoused"
 ];
 (* cSpell: enable *)
@@ -1351,6 +1352,11 @@ parsePodContent[ XMLElement[ "mathml", _, xml_ ] ] :=
 
 parsePodContent[ XMLElement[ $$ignoredXMLTag, _, _ ] ] :=
     { };
+
+parsePodContent[ XMLElement[ unhandledTag_String, _, _ ] ] := (
+    If[ TrueQ @ $wolframAlphaDebug, messagePrint[ "UnhandledWolframAlphaXMLTag", unhandledTag ] ];
+    { }
+);
 
 parsePodContent[ _String ] :=
     { };


### PR DESCRIPTION
## Summary

`RelatedWolframAlphaResults` could fail with an unhandled-pattern error when a Wolfram|Alpha API response contained a subpod element that `parsePodContent` had no definition for (e.g. the newer `subpodcustomizationdata` tag).

- Add `"subpodcustomizationdata"` to `$$ignoredXMLTag`
- Add a catch-all `parsePodContent[XMLElement[unhandledTag_String, _, _]]` definition that ignores any other unknown tag, emitting `Chatbook::UnhandledWolframAlphaXMLTag` when `"Debug" -> True` — the same fallback `parseXML` already has, so future additions to the API degrade gracefully instead of failing

## Test plan

- [x] `Tests/RelatedWolframAlphaResults.wlt` passes
- [x] `RelatedWolframAlphaResults` succeeds on a query whose response includes `subpodcustomizationdata` (previously an unhandled-pattern failure)
- [x] With `"Debug" -> True`, an unrecognized subpod tag prints `Chatbook::UnhandledWolframAlphaXMLTag` and is otherwise skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)