### PR TITLE
Formatting: distinguish between tool calls with/without results

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -1505,6 +1505,10 @@ fancyTooltip[ expr_, tooltip_ ] := Tooltip[
 (* ::Section::Closed:: *)
 (*Parsing Rules*)
 $$endToolCall       = Longest[ "ENDRESULT" ~~ (("(" ~~ (LetterCharacter|DigitCharacter).. ~~ ")") | "") ];
+$$endToolRequest    = "\nENDARGUMENTS\nENDTOOLCALL";
+$$textualToolCall   = RegularExpression[
+    "TOOLCALL:(?:(?!\\nENDARGUMENTS\\nENDTOOLCALL)[\\s\\S])*(?:\\nENDARGUMENTS\\nENDTOOLCALL(?:\\nRESULT\\n[\\s\\S]*?ENDRESULT(?:\\([A-Za-z0-9]+\\))?)?|$)"
+];
 $$eol               = " "... ~~ "\n";
 $$cmd               = Repeated[ Except[ WhitespaceCharacter ], { 1, 80 } ];
 $$simpleToolCommand = StartOfLine ~~ $$ws ~~ ("/" ~~ $$cmd) ~~ $$eol;
@@ -1556,9 +1560,9 @@ $textDataFormatRules = {
             codeBlockCell[ language, code ]
         ]
     ,
-    Longest @ StringExpression[
+    StringExpression[
         (("```" ~~ Except[ "\n" ]... ~~ (" "...) ~~ "\n"))|"",
-        tool: ("TOOLCALL:" ~~ Shortest[ ___ ] ~~ ($$endToolCall|EndOfString))
+        tool: $$textualToolCall
     ] :> inlineToolCallCell @ tool
     ,
     Longest @ StringExpression[
@@ -1653,6 +1657,7 @@ $dynamicSplitRules = {
     ,
     (* Tool call *)
     s: Shortest[ "TOOLCALL:" ~~ ___ ~~ $$endToolCall ] :> s <> "\n",
+    s: Shortest[ "TOOLCALL:" ~~ ___ ~~ $$endToolRequest ] :> s <> "\n",
     s: Shortest[ $$simpleToolCommand ~~ ___ ~~ $$endToolCall ] /; simpleToolCallStringQ @ s :> s
 };
 

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -410,3 +410,68 @@ VerificationTest[
     SameTest -> MatchQ,
     TestID   -> "Manipulate-Boxes-Are-Not-Cached@@Tests/Formatting.wlt:257,1-267,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Textual Tool Calls*)
+
+VerificationTest[
+    Wolfram`Chatbook`Formatting`Private`discardBadToolCalls @ StringSplit[
+        StringRiffle[
+            {
+                "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\n$Failed\nENDRESULT(first)",
+                "/retry",
+                "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL",
+                "Here is the plot:\n\n![Weather plot](attachment://content)\n\n- highs and lows"
+            },
+            "\n\n"
+        ],
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        Wolfram`Chatbook`Formatting`Private`discardedMaterial[
+            Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[ _String ],
+            ""
+        ],
+        "\n",
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL"
+        ],
+        "\n\nHere is the plot:\n\n",
+        Wolfram`Chatbook`Formatting`Private`imageCell[ "Weather plot", "attachment://content" ],
+        "",
+        Wolfram`Chatbook`Formatting`Private`bulletCell[ "", "highs and lows" ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Trailing-Text@@Tests/Formatting.wlt:273,1-302,2"
+]
+
+VerificationTest[
+    StringSplit[
+        "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\ntool output\nENDRESULT(abc123)\n\nTrailing text",
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\ntool output\nENDRESULT(abc123)"
+        ],
+        "\n\nTrailing text"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Completed-Result@@Tests/Formatting.wlt:304,1-317,2"
+]
+
+VerificationTest[
+    StringSplit[
+        "Leading text\n\nTOOLCALL: test\n{\n\t\"code\": \"1 + 1",
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        "Leading text\n\n",
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: test\n{\n\t\"code\": \"1 + 1"
+        ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Partial-Streaming@@Tests/Formatting.wlt:319,1-332,2"
+]


### PR DESCRIPTION
If there is a discarded tool call, then subsequent retries may not include the RESULTS. The final formatted ChatOutput then displays only the tool calls because any concluding text is slurped into the last tool call.