### PR TITLE
Render color constructors as interactive color swatches in chat output

### DIFF
--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -2542,6 +2542,11 @@ formatSpecialBoxes[ boxes_ ] :=
         box: RowBox @ { "DateObject", "[", ___, "]" } :>
             RuleCondition @ formatDateObjectBoxes @ box
         ,
+        box: RowBox @ { $$colorConstructor, "[", ___, "]" } :>
+            With[ { swatch = Quiet @ ToExpression[ box, StandardForm, MakeBoxes ] },
+                swatch /; MatchQ[ swatch, _TemplateBox ]
+            ]
+        ,
         RowBox @ { "Placeholder", "[", label: Except[ RowBox @ { ___, ",", ___ } ], "]" } :>
             RuleCondition @ formatPlaceholderBoxes @ label
         ,
@@ -2552,6 +2557,20 @@ formatSpecialBoxes[ boxes_ ] :=
     };
 
 formatSpecialBoxes // endDefinition;
+
+(* Color constructors that render as interactive color pickers in notebooks: *)
+$$colorConstructor = Alternatives[
+    "CMYKColor",
+    "GrayLevel",
+    "Hue",
+    "LABColor",
+    "LCHColor",
+    "LightDarkSwitched",
+    "LUVColor",
+    "RGBColor",
+    "ThemeColor",
+    "XYZColor"
+];
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/Serialization.wl
+++ b/Source/Chatbook/Serialization.wl
@@ -256,8 +256,12 @@ $templateBoxRules = <|
     "HueColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ],
     "LABColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ],
     "LCHColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ],
+    "LightDarkSwitched"            -> serializeLightDarkSwitched,
+    "LightDarkSwitched1"           -> serializeLightDarkSwitched,
     "LUVColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ],
     "RGBColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ],
+    "ThemeColor"                   -> serializeThemeColor,
+    "ThemeColorBlended"            -> serializeThemeColor,
     "XYZColorSwatchTemplate"       -> inputFormString @* Lookup[ "color" ]
 |>;
 
@@ -3311,6 +3315,32 @@ $inputFormReplacements = {
         "CompressedData[\"\[LeftSkeleton]" <> ToString @ StringLength @ s <> "\[RightSkeleton]\"]",
     "$CellContext`" -> ""
 };
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*serializeLightDarkSwitched*)
+serializeLightDarkSwitched // beginDefinition;
+
+serializeLightDarkSwitched[ KeyValuePattern @ { "light" -> light_, "dark" -> dark_ } ] :=
+    inputFormString @ LightDarkSwitched[ light, dark ];
+
+serializeLightDarkSwitched[ KeyValuePattern[ "light" -> light_ ] ] :=
+    inputFormString @ LightDarkSwitched[ light ];
+
+serializeLightDarkSwitched // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*serializeThemeColor*)
+serializeThemeColor // beginDefinition;
+
+serializeThemeColor[ KeyValuePattern[ "name" -> name_ ] ] :=
+    inputFormString @ ThemeColor[ name ];
+
+serializeThemeColor[ KeyValuePattern @ { "frac1" -> f1_, "name1" -> n1_, "frac2" -> f2_, "name2" -> n2_ } ] :=
+    inputFormString @ ThemeColor[ { f1 -> n1, f2 -> n2 } ];
+
+serializeThemeColor // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -69,7 +69,7 @@ VerificationTest[
         "state" -> "Boxes"
     },
     SameTest -> MatchQ,
-    TestID   -> "TeX-Whitespace-Delimited-Brackets"
+    TestID   -> "TeX-Whitespace-Delimited-Brackets@@Tests/Formatting.wlt:60,1-73,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -81,7 +81,7 @@ VerificationTest[
     FormatChatOutput[ "Cost: \\$5 and \\$6" ],
     RawBoxes @ Cell @ TextData @ { "Cost: $5 and $6" },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-Escaped-Dollar@@Tests/Formatting.wlt:65,1-70,2"
+    TestID   -> "Markdown-Escaped-Dollar@@Tests/Formatting.wlt:80,1-85,2"
 ]
 
 (* Escapes have to be restored before inline code is formatted. Otherwise the escape sentinel is still
@@ -95,7 +95,7 @@ VerificationTest[
         " next"
     },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-Escaped-Dollar-In-Inline-Code@@Tests/Formatting.wlt:75,1-84,2"
+    TestID   -> "Markdown-Escaped-Dollar-In-Inline-Code@@Tests/Formatting.wlt:90,1-99,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -112,7 +112,7 @@ VerificationTest[
         " for details"
     },
     SameTest -> MatchQ,
-    TestID   -> "Inline-Code-Ref-Link@@Tests/Formatting.wlt:92,1-101,2"
+    TestID   -> "Inline-Code-Ref-Link@@Tests/Formatting.wlt:107,1-116,2"
 ]
 
 (* The same holds when the symbol name inside the link was escaped: *)
@@ -124,7 +124,7 @@ VerificationTest[
         " for details"
     },
     SameTest -> MatchQ,
-    TestID   -> "Inline-Code-Ref-Link-Escaped-Name@@Tests/Formatting.wlt:104,1-113,2"
+    TestID   -> "Inline-Code-Ref-Link-Escaped-Name@@Tests/Formatting.wlt:119,1-128,2"
 ]
 
 (* Only a self-referential link is rewritten this way. A label that disagrees with the reference carries
@@ -143,7 +143,7 @@ VerificationTest[
         " for details"
     },
     SameTest -> MatchQ,
-    TestID   -> "Inline-Code-Ref-Link-Mismatched-Name@@Tests/Formatting.wlt:117,1-132,2"
+    TestID   -> "Inline-Code-Ref-Link-Mismatched-Name@@Tests/Formatting.wlt:132,1-147,2"
 ]
 
 (* Combination of link around the function head and escaped brackets around the arguments. *)
@@ -155,7 +155,7 @@ VerificationTest[
     ],
     { "[42]." },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-Escaped-Brackets-After-Link@@Tests/Formatting.wlt:135,1-144,2"
+    TestID   -> "Markdown-Escaped-Brackets-After-Link@@Tests/Formatting.wlt:150,1-159,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -169,7 +169,7 @@ VerificationTest[
     ],
     "/\\_/\\\n( o.o )\n > ^ <",
     SameTest -> MatchQ,
-    TestID   -> "Markdown-ASCII-Art-Backslashes@@Tests/Formatting.wlt:150,1-158,2"
+    TestID   -> "Markdown-ASCII-Art-Backslashes@@Tests/Formatting.wlt:165,1-173,2"
 ]
 
 VerificationTest[
@@ -183,7 +183,7 @@ VerificationTest[
     ],
     ToCharacterCode /@ { " /\\_/\\\\\n( o.o )\n > ^ <" },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-TextFence-Unescapes-ASCII-Art@@Tests/Formatting.wlt:160,1-172,2"
+    TestID   -> "Markdown-TextFence-Unescapes-ASCII-Art@@Tests/Formatting.wlt:175,1-187,2"
 ]
 
 VerificationTest[
@@ -197,7 +197,7 @@ VerificationTest[
     ],
     { "print('\\\\')" },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-CodeFence-Preserves-Code-Backslashes@@Tests/Formatting.wlt:174,1-186,2"
+    TestID   -> "Markdown-CodeFence-Preserves-Code-Backslashes@@Tests/Formatting.wlt:189,1-201,2"
 ]
 
 VerificationTest[
@@ -208,7 +208,7 @@ VerificationTest[
     ],
     { },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-ASCII-Art-Not-ToolCall@@Tests/Formatting.wlt:188,1-197,2"
+    TestID   -> "Markdown-ASCII-Art-Not-ToolCall@@Tests/Formatting.wlt:203,1-212,2"
 ]
 
 VerificationTest[
@@ -219,7 +219,7 @@ VerificationTest[
     ],
     { _Cell },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-External-Slash-ToolCall@@Tests/Formatting.wlt:199,1-208,2"
+    TestID   -> "Markdown-External-Slash-ToolCall@@Tests/Formatting.wlt:214,1-223,2"
 ]
 
 VerificationTest[
@@ -234,7 +234,7 @@ VerificationTest[
     ],
     ToCharacterCode @ "/\\\\_/\\\\\n( o.o )\n > ^ <",
     SameTest -> MatchQ,
-    TestID   -> "Thinking-Preserves-ASCII-Art@@Tests/Formatting.wlt:210,1-223,2"
+    TestID   -> "Thinking-Preserves-ASCII-Art@@Tests/Formatting.wlt:225,1-238,2"
 ]
 
 VerificationTest[
@@ -246,7 +246,7 @@ VerificationTest[
     ],
     "fish & chips /\\\\_/\\\\",
     SameTest -> MatchQ,
-    TestID   -> "Thinking-Escapes-Ignore-Case-And-Import-HTML"
+    TestID   -> "Thinking-Escapes-Ignore-Case-And-Import-HTML@@Tests/Formatting.wlt:240,1-250,2"
 ]
 
 VerificationTest[
@@ -262,7 +262,7 @@ VerificationTest[
     ],
     { True },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-TextFence-Block-Separators@@Tests/Formatting.wlt:225,1-239,2"
+    TestID   -> "Markdown-TextFence-Block-Separators@@Tests/Formatting.wlt:252,1-266,2"
 ]
 
 VerificationTest[
@@ -273,7 +273,7 @@ VerificationTest[
     ],
     { True },
     SameTest -> MatchQ,
-    TestID   -> "Markdown-TextFence-Text-Before-Code@@Tests/Formatting.wlt:241,1-250,2"
+    TestID   -> "Markdown-TextFence-Text-Before-Code@@Tests/Formatting.wlt:268,1-277,2"
 ]
 
 (* ::**************************************************************************************************************:: *)
@@ -291,7 +291,7 @@ VerificationTest[
     ],
     FrameBox[ "\"your data\"" ],
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Boxes@@Tests/Formatting.wlt:258,1-268,2"
+    TestID   -> "Placeholder-Boxes@@Tests/Formatting.wlt:285,1-295,2"
 ]
 
 (* Placeholder allows arbitrary label expressions, so these are formatted too by wrapping the already-parsed
@@ -305,7 +305,7 @@ VerificationTest[
     ],
     FrameBox @ RowBox @ { "your", " ", "data" },
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Expression-Label@@Tests/Formatting.wlt:272,1-282,2"
+    TestID   -> "Placeholder-Expression-Label@@Tests/Formatting.wlt:299,1-309,2"
 ]
 
 (* String labels can contain escaped quotes: *)
@@ -321,7 +321,7 @@ VerificationTest[
     ],
     FrameBox[ "\"{{\\\"Feb 12 2026\\\", 10}, {\\\"Mar 05 2026\\\", 14}, ...}\"" ],
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Escaped-Quotes@@Tests/Formatting.wlt:285,1-298,2"
+    TestID   -> "Placeholder-Escaped-Quotes@@Tests/Formatting.wlt:312,1-325,2"
 ]
 
 (* Placeholder takes at most one argument, so empty or multiple arguments are not valid labels and are left as-is: *)
@@ -329,7 +329,7 @@ VerificationTest[
     StringToBoxes[ "f[Placeholder[a, b], Placeholder[]]", "WL" ],
     boxes_ /; FreeQ[ boxes, TagBox[ _, "Placeholder", ___ ] ],
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Invalid-Arguments-Unchanged@@Tests/Formatting.wlt:301,1-306,2"
+    TestID   -> "Placeholder-Invalid-Arguments-Unchanged@@Tests/Formatting.wlt:328,1-333,2"
 ]
 
 (* The full formatting path renders the placeholder in finished chat output: *)
@@ -342,7 +342,7 @@ VerificationTest[
     ],
     FrameBox[ "\"your data\"" ],
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Formatted-Output@@Tests/Formatting.wlt:309,1-319,2"
+    TestID   -> "Placeholder-Formatted-Output@@Tests/Formatting.wlt:336,1-346,2"
 ]
 
 (* While streaming, code is rendered from plain strings, so the placeholder appears as embedded linear syntax: *)
@@ -356,7 +356,7 @@ VerificationTest[
     ],
     { __ },
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Streaming@@Tests/Formatting.wlt:322,1-333,2"
+    TestID   -> "Placeholder-Streaming@@Tests/Formatting.wlt:349,1-360,2"
 ]
 
 (* A placeholder that has not finished streaming in yet is still rendered: *)
@@ -367,7 +367,7 @@ VerificationTest[
     ],
     { __ },
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Streaming-Partial@@Tests/Formatting.wlt:336,1-344,2"
+    TestID   -> "Placeholder-Streaming-Partial@@Tests/Formatting.wlt:363,1-371,2"
 ]
 
 (* Serializing the formatted boxes back to text for the LLM recovers the original code instead of losing the
@@ -379,7 +379,7 @@ VerificationTest[
     ],
     "```wl\ndata = Placeholder[\"your data\"];\n```",
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Serialization-RoundTrip@@Tests/Formatting.wlt:348,1-356,2"
+    TestID   -> "Placeholder-Serialization-RoundTrip@@Tests/Formatting.wlt:375,1-383,2"
 ]
 
 (* Expression labels round-trip through serialization as well: *)
@@ -390,8 +390,175 @@ VerificationTest[
     ],
     "```wl\nDateListPlot[Placeholder[your data]]\n```",
     SameTest -> MatchQ,
-    TestID   -> "Placeholder-Serialization-RoundTrip-Expression-Label@@Tests/Formatting.wlt:359,1-367,2"
+    TestID   -> "Placeholder-Serialization-RoundTrip-Expression-Label@@Tests/Formatting.wlt:386,1-394,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Color Swatches*)
+
+(* Color constructors with literal numeric arguments get their StandardForm typesetting, so they display as interactive
+   color swatches instead of plain code: *)
+VerificationTest[
+    StringToBoxes[ "RGBColor[1, 0, 0]", "WL" ],
+    TemplateBox[ KeyValuePattern[ "color" -> RGBColor[ 1, 0, 0 ] ], "RGBColorSwatchTemplate", ___ ],
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-RGBColor@@Tests/Formatting.wlt:402,1-407,2"
+]
+
+(* Every supported color model is converted: *)
+VerificationTest[
+    Cases[
+        StringToBoxes[
+            "{CMYKColor[0, 1, 1, 0], GrayLevel[0.5], Hue[0.3], LABColor[50, 20, 30], LCHColor[50, 20, 30], LUVColor[50, 20, 30], XYZColor[0.5, 0.5, 0.5]}",
+            "WL"
+        ],
+        TemplateBox[ KeyValuePattern[ "color" -> color_ ], name_String, ___ ] :> { name, color },
+        Infinity
+    ],
+    {
+        { "CMYKColorSwatchTemplate"     , CMYKColor[ 0, 1, 1, 0 ]   },
+        { "GrayLevelColorSwatchTemplate", GrayLevel[ 0.5 ]          },
+        { "HueColorSwatchTemplate"      , Hue[ 0.3 ]                },
+        { "LABColorSwatchTemplate"      , LABColor[ 50, 20, 30 ]    },
+        { "LCHColorSwatchTemplate"      , LCHColor[ 50, 20, 30 ]    },
+        { "LUVColorSwatchTemplate"      , LUVColor[ 50, 20, 30 ]    },
+        { "XYZColorSwatchTemplate"      , XYZColor[ 0.5, 0.5, 0.5 ] }
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-All-Color-Models@@Tests/Formatting.wlt:410,1-430,2"
+]
+
+(* LightDarkSwitched and ThemeColor typeset to their own template boxes rather than a "...ColorSwatchTemplate": *)
+VerificationTest[
+    Cases[
+        StringToBoxes[ "{LightDarkSwitched[RGBColor[1, 0, 0], RGBColor[0, 1, 0]], LightDarkSwitched[RGBColor[1, 0, 0]]}", "WL" ],
+        TemplateBox[ as_Association, name_String, ___ ] :> { name, as },
+        Infinity
+    ],
+    {
+        { "LightDarkSwitched" , KeyValuePattern @ { "light" -> RGBColor[ 1, 0, 0 ], "dark" -> RGBColor[ 0, 1, 0 ] } },
+        { "LightDarkSwitched1", KeyValuePattern[ "light" -> RGBColor[ 1, 0, 0 ] ] }
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-LightDarkSwitched@@Tests/Formatting.wlt:433,1-445,2"
+]
+
+VerificationTest[
+    Cases[
+        StringToBoxes[ "{ThemeColor[\"Background\"], ThemeColor[{0.3 -> \"Foreground\", 0.7 -> \"Background\"}]}", "WL" ],
+        TemplateBox[ as_Association, name_String, ___ ] :> { name, as },
+        Infinity
+    ],
+    {
+        { "ThemeColor"       , KeyValuePattern[ "name" -> "Background" ] },
+        { "ThemeColorBlended", KeyValuePattern @ { "frac1" -> 0.3, "name1" -> "Foreground", "frac2" -> 0.7, "name2" -> "Background" } }
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-ThemeColor@@Tests/Formatting.wlt:447,1-459,2"
+]
+
+(* Swatches are substituted in place inside larger expressions: *)
+VerificationTest[
+    StringToBoxes[ "Graphics[{RGBColor[1, 0, 0], Disk[]}]", "WL" ],
+    RowBox @ {
+        "Graphics",
+        "[",
+        RowBox @ {
+            "{",
+            RowBox @ {
+                TemplateBox[ KeyValuePattern[ "color" -> RGBColor[ 1, 0, 0 ] ], "RGBColorSwatchTemplate", ___ ],
+                ",",
+                RowBox @ { "Disk", "[", "]" }
+            },
+            "}"
+        },
+        "]"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Nested-In-Expression@@Tests/Formatting.wlt:462,1-480,2"
+]
+
+(* Arguments that are not literal numbers (symbols, patterns, unevaluated expressions) do not typeset as swatches in the
+   front end either, so the code is left as-is: *)
+VerificationTest[
+    StringToBoxes[ "{RGBColor[Red, Green, Blue], Hue[N[1/3]], RGBColor[1, 0], Cases[expr, RGBColor[r_, g_, b_]]}", "WL" ],
+    boxes_ /; FreeQ[ boxes, _TemplateBox ],
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Non-Numeric-Arguments-Unchanged@@Tests/Formatting.wlt:484,1-489,2"
+]
+
+(* When a color is not converted, special boxes inside its arguments are still formatted: *)
+VerificationTest[
+    StringToBoxes[ "RGBColor[Placeholder[\"red\"], 0, 0]", "WL" ],
+    RowBox @ { "RGBColor", "[", RowBox @ { TagBox[ FrameBox[ "\"red\"" ], "Placeholder" ], ",", "0", ",", "0" }, "]" },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Inner-Special-Boxes-Still-Formatted@@Tests/Formatting.wlt:492,1-497,2"
+]
+
+(* The full formatting path renders swatches in finished chat output, both in code and in sandbox output rows: *)
+VerificationTest[
+    Cases[
+        FormatChatOutput[ "```wl\nIn[1]:= RGBColor[1, 0, 0]\nOut[1]= RGBColor[1, 0, 0]\n```\n" ],
+        Cell[ BoxData[ swatch_TemplateBox ], style: "ChatCode"|"Output", ___ ] :> { style, swatch },
+        Infinity
+    ],
+    {
+        { "ChatCode", TemplateBox[ KeyValuePattern[ "color" -> RGBColor[ 1, 0, 0 ] ], "RGBColorSwatchTemplate", ___ ] },
+        { "Output"  , TemplateBox[ KeyValuePattern[ "color" -> RGBColor[ 1, 0, 0 ] ], "RGBColorSwatchTemplate", ___ ] }
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Formatted-Output@@Tests/Formatting.wlt:500,1-512,2"
+]
+
+(* Serializing the formatted boxes back to text for the LLM recovers the original code: *)
+VerificationTest[
+    CellToString @ Cell[
+        BoxData @ StringToBoxes[ "{RGBColor[1, 0, 0], Hue[0.3], GrayLevel[0.5]}", "WL" ],
+        "Output"
+    ],
+    "```wl\n{RGBColor[1, 0, 0], Hue[0.3], GrayLevel[0.5]}\n```",
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Serialization-RoundTrip@@Tests/Formatting.wlt:515,1-523,2"
+]
+
+(* LightDarkSwitched and ThemeColor, including their one-argument and blended variants, round-trip as well: *)
+VerificationTest[
+    CellToString @ Cell[
+        BoxData @ StringToBoxes[
+            "{LightDarkSwitched[RGBColor[1, 0, 0], RGBColor[0, 1, 0]], LightDarkSwitched[RGBColor[1, 0, 0]], ThemeColor[\"Background\"], ThemeColor[{0.3 -> \"Foreground\", 0.7 -> \"Background\"}]}",
+            "WL"
+        ],
+        "Output"
+    ],
+    "```wl\n{LightDarkSwitched[RGBColor[1, 0, 0], RGBColor[0, 1, 0]], LightDarkSwitched[RGBColor[1, 0, 0]], ThemeColor[\"Background\"], ThemeColor[{0.3 -> \"Foreground\", 0.7 -> \"Background\"}]}\n```",
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Serialization-RoundTrip-LightDarkSwitched-ThemeColor@@Tests/Formatting.wlt:526,1-537,2"
+]
+
+(* :!CodeAnalysis::BeginBlock:: *)
+(* :!CodeAnalysis::Disable::PrivateContextSymbol:: *)
+
+(* Those template boxes have precomputed serialization rules, so they do not need the front end stylesheet lookup that
+   undeclared template boxes fall back to: *)
+VerificationTest[
+    Wolfram`Chatbook`Serialization`Private`$templateBoxRules[ #1 ][ #2 ] & @@@ {
+        { "LightDarkSwitched" , <| "light" -> RGBColor[ 1, 0, 0 ], "dark" -> RGBColor[ 0, 1, 0 ] |> },
+        { "LightDarkSwitched1", <| "light" -> RGBColor[ 1, 0, 0 ] |> },
+        { "ThemeColor"        , <| "name" -> "Background" |> },
+        { "ThemeColorBlended" , <| "frac1" -> 0.3, "name1" -> "Foreground", "frac2" -> 0.7, "name2" -> "Background" |> }
+    },
+    {
+        "LightDarkSwitched[RGBColor[1, 0, 0], RGBColor[0, 1, 0]]",
+        "LightDarkSwitched[RGBColor[1, 0, 0]]",
+        "ThemeColor[\"Background\"]",
+        "ThemeColor[{0.3 -> \"Foreground\", 0.7 -> \"Background\"}]"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "ColorSwatch-Serialization-Precomputed-Rules@@Tests/Formatting.wlt:544,1-559,2"
+]
+
+(* :!CodeAnalysis::EndBlock:: *)
 
 (* ::**************************************************************************************************************:: *)
 (* ::Section::Closed:: *)
@@ -408,5 +575,5 @@ VerificationTest[
     ],
     <| |>,
     SameTest -> MatchQ,
-    TestID   -> "Manipulate-Boxes-Are-Not-Cached@@Tests/Formatting.wlt:257,1-267,2"
+    TestID   -> "Manipulate-Boxes-Are-Not-Cached@@Tests/Formatting.wlt:569,1-579,2"
 ]


### PR DESCRIPTION
## Summary

- Color constructors with literal numeric arguments in formatted WL code (`RGBColor`, `Hue`, `GrayLevel`, `CMYKColor`, `LABColor`, `LCHColor`, `LUVColor`, `XYZColor`, `LightDarkSwitched`, `ThemeColor`) now get their StandardForm typesetting via `MakeBoxes`, so they display as the same interactive color swatches they would in a notebook instead of plain input form. This applies to code blocks, `In`/`Out` cell-group rows (including sandbox output), and inline code. Non-numeric arguments (symbols, patterns, unevaluated expressions) are left untouched, matching the front end's own behavior.
- `LightDarkSwitched` and `ThemeColor` typeset to `"LightDarkSwitched"`/`"LightDarkSwitched1"` and `"ThemeColor"`/`"ThemeColorBlended"` template boxes rather than `...ColorSwatchTemplate` ones. These now have precomputed entries in `$templateBoxRules`, so `CellToString` round-trips them without the front end stylesheet lookup used for undeclared template boxes.

## Test plan

- [x] New "Color Swatches" section in `Tests/Formatting.wlt` (11 tests): conversion of every color model, in-place substitution inside larger expressions, non-numeric arguments left unchanged, inner special boxes still formatted when the color rule declines, the full `FormatChatOutput` path including `Out[n]=` rows, serialization round-trips, and the precomputed rules applied directly.
- [x] `Tests/Formatting.wlt` passes (41/41) locally on 15.0.1.
- [x] Verified in a separate kernel that the round trip still works with the stylesheet lookup disabled and that the template box cache stays empty.
- [x] CI on 14.3.0: the `LightDarkSwitched`/`ThemeColor` typesetting (both introduced in 14.2) could only be verified locally on 15.0.1.

## Notes

- `ToExpression` parses the color's arguments before `MakeBoxes` decides whether to produce a swatch, so symbolic arguments such as `RGBColor[r_, g_, b_]` create those symbols in the current context as a side effect. Display is unaffected, and the existing `Entity` and `DateObject` rules behave the same way.
- Streaming output is unchanged; swatches appear once the response is finished, as with `DateObject` and `Entity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EttijYGwk81FLedAkk1e6a
