### PR TITLE
Use Wolfram Engine 15.0 Docker images and require 15.0+

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3.0
+      image: wolframresearch/wolframengine:15.0.0
       options: --user root
 
     env:

--- a/.github/workflows/ExperimentalRelease.yml
+++ b/.github/workflows/ExperimentalRelease.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 15
 
     container:
-      image: wolframresearch/wolframengine:14.3.0
+      image: wolframresearch/wolframengine:15.0.0
       options: --user root
 
     steps:
@@ -51,8 +51,7 @@ jobs:
         unzip -o /tmp/ResourceSystem.zip -d Assets/Snippets/Streamable/ResourceSystem
 
     - name: Build Paclet
-      run: wolframscript -f Scripts/BuildPaclet.wls --snippets=false --wolfram-version=15.0+
-      # TODO: Remove this wolfram-version override once 15.0 docker images are available
+      run: wolframscript -f Scripts/BuildPaclet.wls --snippets=false
 
     - name: Rename Paclet File
       run: mv "${{ env.PACLET_PATH }}" "${{ env.PACLET_BUILD_DIR }}/Wolfram__Chatbook.paclet"

--- a/.github/workflows/IncrementPacletVersion.yml
+++ b/.github/workflows/IncrementPacletVersion.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
 
     container:
-      image: wolframresearch/wolframengine:14.3.0
+      image: wolframresearch/wolframengine:15.0.0
       options: --user root
 
     steps:

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3.0
+      image: wolframresearch/wolframengine:15.0.0
       options: --user root
 
     env:
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 30
 
     container:
-      image: wolframresearch/wolframengine:14.3.0
+      image: wolframresearch/wolframengine:15.0.0
       options: --user root
 
     env:
@@ -91,8 +91,7 @@ jobs:
         unzip -o /tmp/ResourceSystem.zip -d Assets/Snippets/Streamable/ResourceSystem
 
     - name: Build
-      run: wolframscript -f Scripts/BuildPaclet.wls --check=false --snippets=false --wolfram-version=15.0+
-      # TODO: Remove this wolfram-version override once 15.0 docker images are available
+      run: wolframscript -f Scripts/BuildPaclet.wls --check=false --snippets=false
 
     - name: CreateRelease
       env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file provides guidance to AI agents (Claude Code, Cursor, etc.) when workin
 Chatbook (`Wolfram/Chatbook`) is a Wolfram Language paclet that adds LLM-powered notebook support to Wolfram. It integrates chat-based AI interactions directly into Wolfram notebooks, with tool use, prompt augmentation, persona management, and sandboxed code evaluation.
 
 - **Language**: Wolfram Language (`.wl` files)
-- **Requires**: Wolfram Engine 14.3+
+- **Requires**: Wolfram Engine 15.0+
 - **Primary Context**: ``Wolfram`Chatbook` ``
 - **License**: MIT
 
@@ -138,7 +138,7 @@ Always review [testing.md](docs/testing.md) for detailed instructions before mod
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:
-- **Build.yml** — PR validation: build + test (wolframengine:14.3.0 Docker container)
+- **Build.yml** — PR validation: build + test (wolframengine:15.0.0 Docker container)
 - **Release.yml** — Publish to Wolfram Paclet Repository on push to `release/paclet`
 - **IncrementPacletVersion.yml** — Auto-increments version in PacletInfo.wl on main branch pushes
 

--- a/PacletInfo.wl
+++ b/PacletInfo.wl
@@ -2,7 +2,7 @@ PacletObject[ <|
     "Name"           -> "Wolfram/Chatbook",
     "PublisherID"    -> "Wolfram",
     "Version"        -> "2.7.17",
-    "WolframVersion" -> "14.3+",
+    "WolframVersion" -> "15.0+",
     "Description"    -> "Wolfram Notebooks + LLMs",
     "License"        -> "MIT",
     "Creator"        -> "Connor Gray, Theodore Gray, Richard Hennigan, Kevin Daily",
@@ -67,7 +67,7 @@ PacletObject[ <|
         },
         { "FrontEnd",
             "Root" -> "DarkModeSupport",
-            "WolframVersion" -> "14.3+",
+            "WolframVersion" -> "15.0+",
             Prepend -> True
         }
     }

--- a/ResourceDefinition.nb
+++ b/ResourceDefinition.nb
@@ -14048,7 +14048,7 @@ Notebook[
                },
                CellID -> 267876551
               ],
-              Cell["14.3+", "Text", CellID -> 1052559837]
+              Cell["15.0+", "Text", CellID -> 1052559837]
              },
              Open
             ]


### PR DESCRIPTION
## Summary

- Switch all four GitHub Actions workflows from `wolframresearch/wolframengine:14.3.0` to `wolframresearch/wolframengine:15.0.0`.
- Raise the paclet's minimum version to `15.0+` in `PacletInfo.wl` (top level, plus the `DarkModeSupport` extension guard, which is now redundant) and update the matching "Wolfram Language Version" cell in `ResourceDefinition.nb`.
- Remove the `--wolfram-version=15.0+` override (and its TODO) from the Release and ExperimentalRelease workflows. `Scripts/BuildPaclet.wls` asserts that the override actually changes the version, so it would fail now that `PacletInfo.wl` already says `15.0+`.
- Update the `AGENTS.md` notes describing the required engine version and the CI container.

## Test plan

- [x] `wolframresearch/wolframengine:15.0.0` exists on Docker Hub. Pulled and inspected: Ubuntu 24.04, WolframScript 1.14.0, front end binaries present.
- [x] Ran the workflows' `apt-get` / PPA / `unzip` / `libgomp1` / `gh` install steps inside the 15.0.0 container: all succeed.
- [x] All four workflow files parse as YAML. `PacletInfo.wl` loads and the paclet is reported compatible on a 15.0.1 kernel. `ResourceDefinition.nb` imports with the updated cell.
- [x] Ran `wolframscript -f Scripts/BuildPaclet.wls --snippets=false` (the Build workflow's command, with check, MX build, and unformat enabled) on a copy of this branch: succeeds, and the built paclet's `PacletInfo.wl` shows `15.0+`.
- [x] Build workflow on this PR (first CI run on the 15.0.0 image).

## Notes

- `Scripts/CheckPaclet.wls` (which fails on warnings) currently fails on two pre-existing `Throw` warnings in `Source/Chatbook/CodeCheck.wl` (lines 379 and 481). It fails identically on `main`. CI is unaffected because the build-time check only fails on errors. Left for a separate cleanup, together with the `sufficientVersionQ[ 14.3 ]`-style guards in `Source/` that are now always true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYqEzbpLvJHCsN9VdrTpQX
