### PR TITLE
Bugfix/formatting tool call with trailing text

### DIFF
--- a/FrontEnd/TextResources/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "Using ",
 "FormattingToolUsed" -> "Used ",
 "FormattingToolUsingLoading" -> "Using tool\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "Thinking\[Ellipsis]",
 "FormattingThinkingComplete" -> "Thought for `time` seconds",
 "FormattingThinkingCompleteFallback" -> "Thought",

--- a/FrontEnd/TextResources/ChineseSimplified/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/ChineseSimplified/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "\:4F7F\:7528 ",
 "FormattingToolUsed" -> "\:5DF2\:4F7F\:7528 ",
 "FormattingToolUsingLoading" -> "\:4F7F\:7528\:5DE5\:5177\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "\:6B63\:5728\:601D\:8003\[Ellipsis]",
 "FormattingThinkingComplete" -> "\:601D\:8003\:4E86 `time` \:79D2",
 "FormattingThinkingCompleteFallback" -> "\:601D\:8003\:5B8C\:6210",

--- a/FrontEnd/TextResources/ChineseTraditional/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/ChineseTraditional/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "\:6B63\:5728\:4F7F\:7528 ",
 "FormattingToolUsed" -> "\:5DF2\:4F7F\:7528 ",
 "FormattingToolUsingLoading" -> "\:4F7F\:7528\:4E2D\:7684\:5DE5\:5177\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "\:601D\:8003\:4E2D\[Ellipsis]",
 "FormattingThinkingComplete" -> "\:5DF2\:601D\:8003 `time` \:79D2",
 "FormattingThinkingCompleteFallback" -> "\:601D\:8003",

--- a/FrontEnd/TextResources/French/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/French/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "Utilisation de ",
 "FormattingToolUsed" -> "Utilisant ",
 "FormattingToolUsingLoading" -> "Utilisation de l\[CloseCurlyQuote]outil\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "En train de r\[EAcute]fl\[EAcute]chir\[Ellipsis]",
 "FormattingThinkingComplete" -> "A r\[EAcute]fl\[EAcute]chi pendant `time` secondes",
 "FormattingThinkingCompleteFallback" -> "R\[EAcute]flexion",

--- a/FrontEnd/TextResources/Japanese/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/Japanese/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "\:4f7f\:7528\:4e2d\:ff1a",
 "FormattingToolUsed" -> "\:4f7f\:7528\:ff1a",
 "FormattingToolUsingLoading" -> "\:30c4\:30fc\:30eb\:3092\:4f7f\:7528\:3057\:3066\:3044\:307e\:3059\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "\:8003\:3048\:3066\:3044\:307e\:3059\[Ellipsis]",
 "FormattingThinkingComplete" -> "`time`\:79d2\:9593\:8003\:3048\:307e\:3057\:305f",
 "FormattingThinkingCompleteFallback" -> "\:8003\:3048\:307e\:3057\:305f",

--- a/FrontEnd/TextResources/Korean/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/Korean/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "\:C0AC\:C6A9\:C911 ",
 "FormattingToolUsed" -> "\:C0AC\:C6A9 ",
 "FormattingToolUsingLoading" -> "\:B3C4\:AD6C \:C0AC\:C6A9\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "\:C0DD\:AC01\:C911\[Ellipsis]",
 "FormattingThinkingComplete" -> "`time`\:CD08 \:B3D9\:C548 \:C0DD\:AC01",
 "FormattingThinkingCompleteFallback" -> "\:C0DD\:AC01",

--- a/FrontEnd/TextResources/Spanish/ChatbookStrings.tr
+++ b/FrontEnd/TextResources/Spanish/ChatbookStrings.tr
@@ -74,6 +74,7 @@
 "FormattingToolUsing" -> "Utilizando ",
 "FormattingToolUsed" -> "Se utiliz\[OAcute] ",
 "FormattingToolUsingLoading" -> "Utilizando herramienta\[Ellipsis]",
+"FormattingToolRetryIncomplete" -> "The retried tool call did not complete. No tool result was received, so subsequent generated content was discarded.",
 "FormattingThinkingActive" -> "Pensando\[Ellipsis]",
 "FormattingThinkingComplete" -> "Se pens\[OAcute] durante `time`segundos",
 "FormattingThinkingCompleteFallback" -> "Pensado",

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -327,7 +327,7 @@ discardBadToolCalls[ {
     b: Except[ _inlineToolCallCell ]...,
     $discardPreviousToolCall,
     c___
-} ] := discardBadToolCalls @ { a, $lastDiscarded = discardedMaterial[ tc, b ], c };
+} ] := discardBadToolCalls @ { a, $lastDiscarded = discardedMaterial[ tc, b ], $retriedToolCall, c };
 
 discardBadToolCalls[ { a: Except[ _inlineToolCallCell ]..., $discardPreviousToolCall, b___ } ] :=
     discardBadToolCalls @ { a, b };
@@ -336,7 +336,17 @@ discardBadToolCalls[ { a___, discardedMaterial[ b___ ], discardedMaterial[ c___ 
     discardBadToolCalls @ { a, $lastDiscarded = discardedMaterial[ b, c ], d };
 
 discardBadToolCalls[ textData_List ] :=
-    textData;
+    DeleteCases[
+        SequenceReplace[
+            textData,
+            {
+                $retriedToolCall,
+                b: Except[ _inlineToolCallCell ]...,
+                inlineToolCallCell[ string_String ]
+            } :> Sequence[ b, retriedToolCallCell @ string ]
+        ],
+        $retriedToolCall
+    ];
 
 discardBadToolCalls // endDefinition;
 
@@ -456,6 +466,11 @@ makeResultCell0[ sectionCell[ n_, section_String ] ] := Flatten @ {
 makeResultCell0[ inlineToolCallCell[ string_String ] ] := (
     $lastToolCallString = string;
     $lastFormattedToolCall = inlineToolCall @ string
+);
+
+makeResultCell0[ retriedToolCallCell[ string_String ] ] := (
+    $lastToolCallString = string;
+    $lastFormattedToolCall = retriedToolCall @ string
 );
 
 makeResultCell0[ tableCell[ string_String ] ] :=
@@ -1507,7 +1522,7 @@ fancyTooltip[ expr_, tooltip_ ] := Tooltip[
 $$endToolCall       = Longest[ "ENDRESULT" ~~ (("(" ~~ (LetterCharacter|DigitCharacter).. ~~ ")") | "") ];
 $$endToolRequest    = "\nENDARGUMENTS\nENDTOOLCALL";
 $$textualToolCall   = RegularExpression[
-    "TOOLCALL:(?:(?!\\nENDARGUMENTS\\nENDTOOLCALL)[\\s\\S])*(?:\\nENDARGUMENTS\\nENDTOOLCALL(?:\\nRESULT\\n[\\s\\S]*?ENDRESULT(?:\\([A-Za-z0-9]+\\))?)?|$)"
+    "TOOLCALL:(?:(?!\\nENDARGUMENTS\\nENDTOOLCALL\\nRESULT\\n)[\\s\\S])*(?:\\nENDARGUMENTS\\nENDTOOLCALL\\nRESULT\\n[\\s\\S]*?ENDRESULT(?:\\([A-Za-z0-9]+\\))?|$)"
 ];
 $$eol               = " "... ~~ "\n";
 $$cmd               = Repeated[ Except[ WhitespaceCharacter ], { 1, 80 } ];
@@ -1796,6 +1811,36 @@ inlineToolCall[ string_String, as_ ] :=
     ];
 
 inlineToolCall // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*retriedToolCall*)
+retriedToolCall // beginDefinition;
+
+retriedToolCall[ string_String ] :=
+    If[ TrueQ @ $dynamicText || StringContainsQ[ string, "\nRESULT\n" ~~ ___ ~~ $$endToolCall ],
+        inlineToolCall @ string,
+        retriedToolCallErrorCell[ ]
+    ];
+
+retriedToolCall // endDefinition;
+
+(* ::**************************************************************************************************************:: *)
+(* ::Subsubsection::Closed:: *)
+(*retriedToolCallErrorCell*)
+retriedToolCallErrorCell // beginDefinition;
+
+retriedToolCallErrorCell[ ] := Cell[
+    BoxData @ ToBoxes @ errorMessageBox[
+        tr @ "FormattingToolRetryIncomplete",
+        Appearance -> "Fatal",
+        ImageSize  -> { Scaled[ 1 ], Automatic }
+    ],
+    "Text",
+    Background -> None
+];
+
+retriedToolCallErrorCell // endDefinition;
 
 (* ::**************************************************************************************************************:: *)
 (* ::Subsubsection::Closed:: *)

--- a/Source/Chatbook/Formatting.wl
+++ b/Source/Chatbook/Formatting.wl
@@ -1505,6 +1505,10 @@ fancyTooltip[ expr_, tooltip_ ] := Tooltip[
 (* ::Section::Closed:: *)
 (*Parsing Rules*)
 $$endToolCall       = Longest[ "ENDRESULT" ~~ (("(" ~~ (LetterCharacter|DigitCharacter).. ~~ ")") | "") ];
+$$endToolRequest    = "\nENDARGUMENTS\nENDTOOLCALL";
+$$textualToolCall   = RegularExpression[
+    "TOOLCALL:(?:(?!\\nENDARGUMENTS\\nENDTOOLCALL)[\\s\\S])*(?:\\nENDARGUMENTS\\nENDTOOLCALL(?:\\nRESULT\\n[\\s\\S]*?ENDRESULT(?:\\([A-Za-z0-9]+\\))?)?|$)"
+];
 $$eol               = " "... ~~ "\n";
 $$cmd               = Repeated[ Except[ WhitespaceCharacter ], { 1, 80 } ];
 $$simpleToolCommand = StartOfLine ~~ $$ws ~~ ("/" ~~ $$cmd) ~~ $$eol;
@@ -1556,9 +1560,9 @@ $textDataFormatRules = {
             codeBlockCell[ language, code ]
         ]
     ,
-    Longest @ StringExpression[
+    StringExpression[
         (("```" ~~ Except[ "\n" ]... ~~ (" "...) ~~ "\n"))|"",
-        tool: ("TOOLCALL:" ~~ Shortest[ ___ ] ~~ ($$endToolCall|EndOfString))
+        tool: $$textualToolCall
     ] :> inlineToolCallCell @ tool
     ,
     Longest @ StringExpression[
@@ -1653,6 +1657,7 @@ $dynamicSplitRules = {
     ,
     (* Tool call *)
     s: Shortest[ "TOOLCALL:" ~~ ___ ~~ $$endToolCall ] :> s <> "\n",
+    s: Shortest[ "TOOLCALL:" ~~ ___ ~~ $$endToolRequest ] :> s <> "\n",
     s: Shortest[ $$simpleToolCommand ~~ ___ ~~ $$endToolCall ] /; simpleToolCallStringQ @ s :> s
 };
 

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -577,3 +577,68 @@ VerificationTest[
     SameTest -> MatchQ,
     TestID   -> "Manipulate-Boxes-Are-Not-Cached@@Tests/Formatting.wlt:569,1-579,2"
 ]
+
+(* ::**************************************************************************************************************:: *)
+(* ::Section::Closed:: *)
+(*Textual Tool Calls*)
+
+VerificationTest[
+    Wolfram`Chatbook`Formatting`Private`discardBadToolCalls @ StringSplit[
+        StringRiffle[
+            {
+                "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\n$Failed\nENDRESULT(first)",
+                "/retry",
+                "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL",
+                "Here is the plot:\n\n![Weather plot](attachment://content)\n\n- highs and lows"
+            },
+            "\n\n"
+        ],
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        Wolfram`Chatbook`Formatting`Private`discardedMaterial[
+            Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[ _String ],
+            ""
+        ],
+        "\n",
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL"
+        ],
+        "\n\nHere is the plot:\n\n",
+        Wolfram`Chatbook`Formatting`Private`imageCell[ "Weather plot", "attachment://content" ],
+        "",
+        Wolfram`Chatbook`Formatting`Private`bulletCell[ "", "highs and lows" ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Trailing-Text@@Tests/Formatting.wlt:273,1-302,2"
+]
+
+VerificationTest[
+    StringSplit[
+        "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\ntool output\nENDRESULT(abc123)\n\nTrailing text",
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\ntool output\nENDRESULT(abc123)"
+        ],
+        "\n\nTrailing text"
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Completed-Result@@Tests/Formatting.wlt:304,1-317,2"
+]
+
+VerificationTest[
+    StringSplit[
+        "Leading text\n\nTOOLCALL: test\n{\n\t\"code\": \"1 + 1",
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        "Leading text\n\n",
+        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
+            "TOOLCALL: test\n{\n\t\"code\": \"1 + 1"
+        ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Partial-Streaming@@Tests/Formatting.wlt:319,1-332,2"
+]

--- a/Tests/Formatting.wlt
+++ b/Tests/Formatting.wlt
@@ -601,16 +601,118 @@ VerificationTest[
             ""
         ],
         "\n",
-        Wolfram`Chatbook`Formatting`Private`inlineToolCallCell[
-            "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL"
-        ],
-        "\n\nHere is the plot:\n\n",
-        Wolfram`Chatbook`Formatting`Private`imageCell[ "Weather plot", "attachment://content" ],
-        "",
-        Wolfram`Chatbook`Formatting`Private`bulletCell[ "", "highs and lows" ]
+        Wolfram`Chatbook`Formatting`Private`retriedToolCallCell[
+            "TOOLCALL: wolfram_language_evaluator\n{}\nENDARGUMENTS\nENDTOOLCALL\n\n" <>
+            "Here is the plot:\n\n![Weather plot](attachment://content)\n\n- highs and lows"
+        ]
     },
     SameTest -> MatchQ,
     TestID   -> "Textual-Tool-Call-Trailing-Text@@Tests/Formatting.wlt:273,1-302,2"
+]
+
+VerificationTest[
+    Block[ { Wolfram`Chatbook`Formatting`Private`$dynamicText = False },
+        Wolfram`Chatbook`Formatting`Private`retriedToolCall[
+            "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\n\nFabricated result"
+        ]
+    ],
+    Cell[ BoxData[ _ ], "Text", ___ ],
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Incomplete-Retry-Fails"
+]
+
+VerificationTest[
+    FreeQ[
+        Block[ { Wolfram`Chatbook`Formatting`Private`$dynamicText = False },
+            Wolfram`Chatbook`Formatting`Private`retriedToolCall[
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\n\nFabricated result"
+            ]
+        ],
+        _Failure
+    ],
+    True,
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Incomplete-Retry-Does-Not-Render-Failure"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`Formatting`Private`formatChatOutput[
+        StringRiffle[
+            {
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\nfailed\nENDRESULT(first)",
+                "/retry",
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\n\nFabricated result"
+            },
+            "\n\n"
+        ],
+        "Finished"
+    ],
+    RawBoxes @ Cell @ TextData @ {
+        Cell[ _, "DiscardedMaterial", ___ ],
+        _String,
+        Cell[ BoxData[ _ ], "Text", ___ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Incomplete-Retry-Finished-Output"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`Formatting`Private`formatChatOutput[
+        StringRiffle[
+            {
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\nfailed\nENDRESULT(first)",
+                "/retry",
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL"
+            },
+            "\n\n"
+        ],
+        "Streaming"
+    ],
+    RawBoxes @ Cell @ TextData @ {
+        Cell[ _, "DiscardedMaterial", ___ ],
+        _String,
+        Cell[ _, "InlineToolCall", ___ ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Incomplete-Retry-Streams"
+]
+
+VerificationTest[
+    Block[ { Wolfram`Chatbook`Formatting`Private`$dynamicText = False },
+        Wolfram`Chatbook`Formatting`Private`retriedToolCall[
+            "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\ntool output\nENDRESULT(abc123)"
+        ]
+    ],
+    Cell[ _, "InlineToolCall", ___ ],
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Completed-Retry-Succeeds"
+]
+
+VerificationTest[
+    Wolfram`Chatbook`Formatting`Private`discardBadToolCalls @ StringSplit[
+        StringRiffle[
+            {
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\nfirst failure\nENDRESULT(first)",
+                "/retry",
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\nRESULT\nsecond failure\nENDRESULT(second)",
+                "/retry",
+                "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\n\nFabricated result"
+            },
+            "\n\n"
+        ],
+        Wolfram`Chatbook`Formatting`Private`$textDataFormatRules
+    ],
+    {
+        Wolfram`Chatbook`Formatting`Private`discardedMaterial[ ___ ],
+        "\n",
+        Wolfram`Chatbook`Formatting`Private`discardedMaterial[ ___ ],
+        "\n",
+        Wolfram`Chatbook`Formatting`Private`retriedToolCallCell[
+            "TOOLCALL: test\n{}\nENDARGUMENTS\nENDTOOLCALL\n\nFabricated result"
+        ]
+    },
+    SameTest -> MatchQ,
+    TestID   -> "Textual-Tool-Call-Multiple-Retries"
 ]
 
 VerificationTest[


### PR DESCRIPTION
Second attempt of this PR. Recognizing that the failed tool call is a true error, we display an error cell in the formatted output:
<img width="871" height="228" alt="image" src="https://github.com/user-attachments/assets/78295b8a-7053-40e5-8352-6ca156d2b89d" />